### PR TITLE
Allow building & running with Burp free edition (limited capabilities)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Burp
 # =============================
 lib/burpsuite_pro_*.jar
+lib/burpsuite_free_*.jar
 
 build/
 **/.DS_Store

--- a/README.md
+++ b/README.md
@@ -19,29 +19,26 @@ Upon successfully building the project, an executable JAR file is created with t
 
 ### Build & Run
 
-1. [Download](https://portswigger.net/burp/download.html) the Professional edition of Burp Suite.
-2. Create a _lib_ folder under the project directory and place the Burp Suite JAR file into it.
-3. To build, run the following command from the project directory:
-
-```
-    gradlew clean build
-```
-
-4. The project can be run either by running the Gradle Spring `bootRun` command or by directly launching the JAR
+1. [Download](https://portswigger.net/burp/download.html) the Professional edition of Burp Suite. You _may_ use Free edition but capabilities are limited.
+2. Create a `lib` folder under the project directory and place the Burp Suite JAR file into it.
+3. The project can be run either by running the Gradle Spring `bootRun` command or by directly launching the JAR
  created from building the project:
 
 ```
-    gradlew bootRun
+    gradlew bootRun # for pro edition, or
+    gradlew bootRun "-Dburp.edition=free" # for free edition
 ```
 
 or
 
 ```
+    # build the jar (note that testing phase will fail if you provide free edition jar in ./lib)
     gradlew clean build
-    cd build/libs
-    java -jar burp-rest-api-1.0.0.jar
+    # and run it
+    java -jar build/libs/burp-rest-api-1.0.0.jar # for pro edition, or
+    java -jar build/libs/burp-rest-api-1.0.0.jar --burp.edition=free # for free edition
 ```
-The version number of the JAR should match the version number from _build.gradle_ while generating the JAR.
+The version number of the JAR should match the version number from `build.gradle` while generating the JAR.
 
 ## Documentation
 

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -239,6 +239,11 @@ public class BurpService {
       BurpExtender.getInstance().getCallbacks().sendToSpider(url);
    }
 
+   public void restoreState(File state) {
+      log.info("Restoring state by replacing state with a new state");
+      BurpExtender.getInstance().getCallbacks().restoreState(state);
+   }
+
    public void exitSuite(boolean promptUser) {
       log.info("Shutting down the Burp Suite...");
       if (awtHeadLessMode && promptUser) {

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -51,14 +51,14 @@ public class BurpService {
    private boolean awtHeadLessMode;
 
    @Autowired
-   public BurpService(ApplicationArguments args, @Value("${headless.mode}") boolean headlessMode)
+   public BurpService(ApplicationArguments args, @Value("${headless.mode}") boolean headlessMode, @Value("${burp.edition}") String burpEdition)
          throws IOException {
       if (!headlessMode) {
          log.info("Setting java.awt.headless to false...");
          System.setProperty("java.awt.headless", Boolean.toString(false));
       }
       log.info("# of command line arguments received to Burp suite: {}", args.getSourceArgs().length);
-      log.info("Launching the Burp suite in {} mode...", headlessMode ? "headless" : "UI");
+      log.info("Launching the Burp suite ({} edition) in {} mode...", burpEdition, headlessMode ? "headless" : "UI");
 
       if (args.getSourceArgs().length == 0 || !args.containsOption(PROJECT_FILE)) {
          Resource defaultProjectOptionsFile = new ClassPathResource(
@@ -82,8 +82,14 @@ public class BurpService {
          String configFileArgumentWithUserOptions =
                CONFIG_FILE_ARGUMENT + userOptionsTempFile.toAbsolutePath();
 
-         String[] burpOptions = new String[] { projectFileArgument,
-               configFileArgumentWithProjectOptions, configFileArgumentWithUserOptions };
+         // Free edition does not allow PROJECT_FILE_ARGUMENT
+         String[] burpOptions;
+         if (burpEdition.equalsIgnoreCase("free")) {
+            burpOptions = new String[] { configFileArgumentWithProjectOptions, configFileArgumentWithUserOptions };
+         } else {
+            burpOptions = new String[] { projectFileArgument,
+                  configFileArgumentWithProjectOptions, configFileArgumentWithUserOptions };
+         }
 
          log.info("Launching the Burp suite with options: {}", Arrays.toString(burpOptions));
          burp.StartBurp.main(burpOptions);

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.File;
 import java.net.MalformedURLException;
 
 import static org.springframework.web.bind.annotation.RequestMethod.*;
@@ -326,6 +327,14 @@ public class BurpController {
       }
 
       burp.sendToSpider(baseUrl);
+   }
+
+   @ApiOperation(value = "Clean Burp state", notes = "This will restore Burp's state with an empty one.")
+   @RequestMapping(method = GET, value = "/reset")
+   public void resetState(){
+      File emptyState = new File("../../src/main/resources/cleanstate");
+      burp.restoreState(emptyState);
+      log.info("Burp state is reset to clean");
    }
 
    @ApiOperation(value = "Stop Burp Suite", notes = "This will exit Burp Suite. Use with caution: the API will not work after this endpoint has been called. You have to restart Burp from command-line to re-enable te API.")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,6 @@ server:
 
 headless:
   mode: ${java.awt.headless}
+
+burp:
+  edition: pro


### PR DESCRIPTION
Changes:
1. Add a `--burp.edition=[free|pro]` option (default to `pro`) that allows running with free edition jar, which refuses the --project-file cmd argument. (see issue #9)
2. Add a `/burp/reset` endpoint that replace current state with a clean state, effectively reset the workspace.