### PR TITLE
Removed Burp Extender Deprecated APIs, Fixed test errors, Switched To…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'eclipse'
 apply plugin: 'spring-boot'
 
 String BURP_REST_EXTENSION_JAR_NAME = 'burp-rest-api'
-String BURP_REST_EXTENSION_JAR_VERSION = '1.0.0'
+String BURP_REST_EXTENSION_JAR_VERSION = '1.0.1'
 
 jar {
     baseName = BURP_REST_EXTENSION_JAR_NAME
@@ -39,10 +39,12 @@ File schemaTargetDir = new File('build/generated-schema')
 
 configurations {
   jaxb
+    compile.exclude module: "spring-boot-starter-tomcat"
 }
 
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-web')
+    compile("org.springframework.boot:spring-boot-starter-jetty")
     compile fileTree(dir: 'lib', include: '**/*.jar')
     compile "io.springfox:springfox-swagger2:2.+"
     compile "io.springfox:springfox-swagger-ui:2.+"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Sun Sep 25 23:30:07 PDT 2016
+#Wed Feb 14 15:54:11 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -10,13 +10,8 @@ import burp.BurpExtender;
 import burp.IHttpRequestResponse;
 import burp.IScanIssue;
 import burp.IScanQueueItem;
-import com.vmware.burp.extension.domain.Config;
-import com.vmware.burp.extension.domain.ConfigItem;
-import com.vmware.burp.extension.domain.HttpMessage;
-import com.vmware.burp.extension.domain.ReportType;
-import com.vmware.burp.extension.domain.ScanIssue;
+import com.vmware.burp.extension.domain.*;
 import com.vmware.burp.extension.domain.internal.ScanQueueMap;
-import com.vmware.burp.extension.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +31,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class BurpService {
@@ -114,31 +108,6 @@ public class BurpService {
    public void updateConfigFromJson(String configJson) {
       log.info("Updating the Burp Configuration...");
       BurpExtender.getInstance().getCallbacks().loadConfigFromJson(configJson);
-   }
-
-   public Config getConfig() {
-      Map<String, String> configMap = BurpExtender.getInstance().getCallbacks().saveConfig();
-
-      List<ConfigItem> configItems = new ArrayList<>();
-      for (String property : configMap.keySet()) {
-         ConfigItem configItem = new ConfigItem(property, configMap.get(property));
-         configItems.add(configItem);
-      }
-      return new Config(configItems);
-   }
-
-   public void setConfig(Config config) {
-      log.info("Setting the Burp Configuration");
-      Map<String, String> configMap = Utils.convertConfigurationListToMap(config);
-      BurpExtender.getInstance().getCallbacks().loadConfig(configMap);
-   }
-
-   public void updateConfig(Config config) {
-      Map<String, String> existingConfiguration = BurpExtender.getInstance().getCallbacks()
-            .saveConfig();
-      existingConfiguration.putAll(Utils.convertConfigurationListToMap(config));
-      log.info("Updating the Burp Configuration");
-      BurpExtender.getInstance().getCallbacks().loadConfig(existingConfiguration);
    }
 
    public List<HttpMessage> getProxyHistory() {
@@ -237,11 +206,6 @@ public class BurpService {
    public void sendToSpider(String baseUrl) throws MalformedURLException {
       URL url = new URL(baseUrl);
       BurpExtender.getInstance().getCallbacks().sendToSpider(url);
-   }
-
-   public void restoreState(File state) {
-      log.info("Restoring state by replacing state with a new state");
-      BurpExtender.getInstance().getCallbacks().restoreState(state);
    }
 
    public void exitSuite(boolean promptUser) {

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -8,7 +8,6 @@ package com.vmware.burp.extension.web;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.vmware.burp.extension.domain.Config;
 import com.vmware.burp.extension.domain.HttpMessageList;
 import com.vmware.burp.extension.domain.ReportType;
 import com.vmware.burp.extension.domain.ScanIssueList;
@@ -76,58 +75,6 @@ public class BurpController {
          throw new IllegalArgumentException("Required: Configuration in request body.");
       }
       burp.updateConfigFromJson(configAsJson);
-   }
-
-   // TODO: Remove this once Burp suite removes the saveConfig() API from interface files.
-   @Deprecated
-   @ApiOperation(value = "Get all the current Burp suite configuration", notes = "Complete current Burp suite configuration is returned.")
-   @ApiResponses(value = {
-         @ApiResponse(code = 200, message = "Success", response = Config.class),
-         @ApiResponse(code = 500, message = "Failure")
-   })
-   @RequestMapping(method = GET, value = "/config")
-   public Config getConfig() {
-      return burp.getConfig();
-   }
-
-   // TODO: Remove this once Burp suite removes the loadConfig() API from interface files.
-   @Deprecated
-   @ApiOperation(value = "Set new configuration in Burp suite", notes = "Current Burp suite configuration is overwritten with given configuration.")
-   @ApiImplicitParams({
-         @ApiImplicitParam(name = "config", value = "New configuration to set.", required = true, dataType = "Config", paramType = "body")
-   })
-   @ApiResponses(value = {
-         @ApiResponse(code = 200, message = "Success"),
-         @ApiResponse(code = 400, message = "Bad Request"),
-         @ApiResponse(code = 500, message = "Failure")
-   })
-   @RequestMapping(method = POST, value = "/config")
-   public void setConfig(@RequestBody Config config) {
-      if (config == null) {
-         throw new IllegalArgumentException("Required: Configuration in request body.");
-      }
-
-      burp.setConfig(config);
-   }
-
-   // TODO: Remove this once Burp suite removes the loadConfig() API from interface files.
-   @Deprecated
-   @ApiOperation(value = "Update current configuration in Burp suite", notes = "Current Burp suite configuration is updated with given configuration.")
-   @ApiImplicitParams({
-         @ApiImplicitParam(name = "config", value = "Configuration to modify.", required = true, dataType = "Config", paramType = "body")
-   })
-   @ApiResponses(value = {
-         @ApiResponse(code = 200, message = "Success"),
-         @ApiResponse(code = 400, message = "Bad Request"),
-         @ApiResponse(code = 500, message = "Failure")
-   })
-   @RequestMapping(method = PUT, value = "/config")
-   public void updateConfig(@RequestBody Config config) {
-      if (config == null) {
-         throw new IllegalArgumentException("Required: Configuration in request body.");
-      }
-
-      burp.updateConfig(config);
    }
 
    @ApiOperation(value = "Get Burp suite Proxy History", notes = "Returns details of items in Burp Suite Proxy history.")
@@ -327,14 +274,6 @@ public class BurpController {
       }
 
       burp.sendToSpider(baseUrl);
-   }
-
-   @ApiOperation(value = "Clean Burp state", notes = "This will restore Burp's state with an empty one.")
-   @RequestMapping(method = GET, value = "/reset")
-   public void resetState(){
-      File emptyState = new File("../../src/main/resources/cleanstate");
-      burp.restoreState(emptyState);
-      log.info("Burp state is reset to clean");
    }
 
    @ApiOperation(value = "Stop Burp Suite", notes = "This will exit Burp Suite. Use with caution: the API will not work after this endpoint has been called. You have to restart Burp from command-line to re-enable te API.")


### PR DESCRIPTION
Please find enclosed a PR with the following improvements:

- Deprecated _restoreState(java.io.File file)_, _saveConfig()_ and _loadConfig(java.util.Map<java.lang.String,java.lang.String> config)_ from Burp Extender's API are now removed and no longer supported by this extension. See [https://portswigger.net/burp/extender/api/](https://portswigger.net/burp/extender/api/) for more details

- Burp Client tests had a few problems after deprecating the above APIs, thus I fixed these too. Additionally, new versions of Burp had issues establishing SSL connections to the target servers (I think due to SNI) thus it was not picking up the right x509 certificate. Considering it's a test, I simply created a custom _SSLConnectionSocketFactory_ to disable Hostname verification

- Improved memory footprint switching SpringBoot from Tomcat to Jetty


