### PR TITLE
Removing URL startWith check prior to scanning

### DIFF
--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -188,25 +188,23 @@ public class BurpService {
                 if(url.getPort() == url.getDefaultPort()) {
                     url = new URL(url.getProtocol(), url.getHost(), url.getFile());
                 }
-                if (url.toExternalForm().startsWith(baseUrl)) {
-                    boolean useHttps = url.getProtocol().equalsIgnoreCase("HTTPS");
-                    if(isActive) {
-                        //Trigger Burp's Active Scan
-                        log.debug("Submitting Active Scan for the URL {}", url.toExternalForm());
-                        IScanQueueItem iScanQueueItem = BurpExtender.getInstance().getCallbacks()
-                                .doActiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
-                                        iHttpRequestResponse.getRequest());
-                        scans.addItem(url.toExternalForm(), iScanQueueItem);
-                    }else{
-                        //Trigger Burp's Passive Scan
-                        log.debug("Submitting Passive Scan for the URL {}", url.toExternalForm());
-                        if (iHttpRequestResponse.getResponse() != null) {
-                            BurpExtender.getInstance().getCallbacks()
-                                    .doPassiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
-                                            iHttpRequestResponse.getRequest(), iHttpRequestResponse.getResponse());
-                        }
-                    }
-                }
+				boolean useHttps = url.getProtocol().equalsIgnoreCase("HTTPS");
+				if(isActive) {
+					//Trigger Burp's Active Scan
+					log.debug("Submitting Active Scan for the URL {}", url.toExternalForm());
+					IScanQueueItem iScanQueueItem = BurpExtender.getInstance().getCallbacks()
+							.doActiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
+									iHttpRequestResponse.getRequest());
+					scans.addItem(url.toExternalForm(), iScanQueueItem);
+				}else{
+					//Trigger Burp's Passive Scan
+					log.debug("Submitting Passive Scan for the URL {}", url.toExternalForm());
+					if (iHttpRequestResponse.getResponse() != null) {
+						BurpExtender.getInstance().getCallbacks()
+								.doPassiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
+										iHttpRequestResponse.getRequest(), iHttpRequestResponse.getResponse());
+					}
+				}                
             }
             return true;
         } else {
@@ -291,5 +289,4 @@ public class BurpService {
         }
         BurpExtender.getInstance().getCallbacks().exitSuite(promptUser);
     }
-
 }


### PR DESCRIPTION
Removed this check - why is it necessary? I found that this was causing issues scanning using SSL and a URL /subdirectory/ - i.e. initiating a scan on https://test.com/en:

url.toExternalForm() is **https://test.com:443/en/somepage**
baseUrl is **https://test.com/en**
url.toExternalForm().startsWith(baseUrl) is **false**
