### PR TITLE
Make URL checks ignore default port specifications

### DIFF
--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -182,11 +182,14 @@ public class BurpService {
             for (IHttpRequestResponse iHttpRequestResponse : siteMapInScope) {
                 URL url = BurpExtender.getInstance().getHelpers().analyzeRequest(iHttpRequestResponse)
                         .getUrl();
+                if(url.getPort() == url.getDefaultPort()) {
+                    url = new URL(url.getProtocol(), url.getHost(), url.getFile());
+                }
                 if (url.toExternalForm().startsWith(baseUrl)) {
                     boolean useHttps = url.getProtocol().equalsIgnoreCase("HTTPS");
                     log.debug("Submitting Active Scan for the URL {}", url.toExternalForm());
                     IScanQueueItem iScanQueueItem = BurpExtender.getInstance().getCallbacks()
-                            .doActiveScan(url.getHost(), url.getPort(), useHttps,
+                            .doActiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
                                     iHttpRequestResponse.getRequest());
                     scans.addItem(url.toExternalForm(), iScanQueueItem);
                 }


### PR DESCRIPTION
A user reported that using burp-rest-api to Spider and Scan a site did not work. On investigation this is due to a subtlety of URL handling. If they Spider http://foo/ then the site map returns items with URLs http://foo:80/ and if they then scan http://foo/ this doesn't match the URLs like http://foo:80/

This pull request fixes that behavior.