### PR TITLE
Passive Scan / Spider Status / Scan Status Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'eclipse'
 apply plugin: 'spring-boot'
 
 final def extensionName = 'burp-rest-api'
-version = '1.0.2'
+version = '1.0.3'
 
 def updateVersion() {
     def configFile = new File('src/main/resources/application.yml')

--- a/src/main/java/com/vmware/burp/extension/domain/SpiderProgress.java
+++ b/src/main/java/com/vmware/burp/extension/domain/SpiderProgress.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.vmware.burp.extension.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "spiderProgress")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class SpiderProgress {
+    @JsonProperty("spiderPercentage")
+    @XmlElement(name = "spiderPercentage", required = true)
+    private int totalSpiderPercentage;
+
+    public int getTotalSpiderPercentage() {
+        return totalSpiderPercentage;
+    }
+
+    public void setTotalSpiderPercentage(int totalSpiderPercentage) {
+        this.totalSpiderPercentage = totalSpiderPercentage;
+    }
+}

--- a/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
@@ -70,8 +70,12 @@ public class ScanQueueMap {
             totalPercentCompletion += iScanQueueItem.getPercentageComplete();
          }
       }
-      int percentComplete = totalPercentCompletion / numberOfScans;
-      log.info("Scan Percent Complete: {}", percentComplete);
-      return percentComplete;
+      if(totalPercentCompletion > 0) {
+         int percentComplete = totalPercentCompletion / numberOfScans;
+         log.info("Scan Percent Complete: {}", percentComplete);
+         return percentComplete;
+      }else{
+         return 0;
+      }
    }
 }

--- a/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
@@ -66,7 +66,9 @@ public class ScanQueueMap {
       int totalPercentCompletion = 0;
       for (String url : map.keySet()) {
          for (IScanQueueItem iScanQueueItem : getQueue(url)) {
-            if(!iScanQueueItem.getStatus().equalsIgnoreCase("cancelled")) {
+            if (iScanQueueItem.getStatus().equalsIgnoreCase("cancelled") || iScanQueueItem.getStatus().contains("abandoned")) {
+               log.info("Scan Queue Item 'cancelled' or 'abandoned'");
+            } else {
                numberOfScans++;
                totalPercentCompletion += iScanQueueItem.getPercentageComplete();
             }

--- a/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
@@ -66,8 +66,10 @@ public class ScanQueueMap {
       int totalPercentCompletion = 0;
       for (String url : map.keySet()) {
          for (IScanQueueItem iScanQueueItem : getQueue(url)) {
-            numberOfScans++;
-            totalPercentCompletion += iScanQueueItem.getPercentageComplete();
+            if(!iScanQueueItem.getStatus().equalsIgnoreCase("cancelled")) {
+               numberOfScans++;
+               totalPercentCompletion += iScanQueueItem.getPercentageComplete();
+            }
          }
       }
       if(totalPercentCompletion > 0) {

--- a/src/main/java/com/vmware/burp/extension/domain/internal/SpiderQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/SpiderQueueMap.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.vmware.burp.extension.domain.internal;
+
+import burp.BurpExtender;
+import burp.IHttpRequestResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class SpiderQueueMap {
+    private static final Logger log = LoggerFactory.getLogger(SpiderQueueMap.class);
+    private int timeBetweenChecks;
+    // This map holds the url string as Key, and corresponding list of HTTP messages (siteMap) for that url.
+    // Since Burp Extender APIs (as of v1.7.33) does not include a native method to check the status of the spider, we are periodically comparing the state of siteMap.
+    private Map<String, IHttpRequestResponse[]> map = new HashMap<>();
+
+    public SpiderQueueMap(int timeBetweenChecks){
+        this.timeBetweenChecks = timeBetweenChecks;
+    }
+
+    public void addItem(String url, IHttpRequestResponse[] siteMapUrl) {
+        if (map.containsKey(url)) {
+            map.remove(url);
+        }
+        map.put(url, siteMapUrl);
+    }
+
+    public boolean hasUrl(String urlToSearch) {
+        for (String url : map.keySet()) {
+            if (url.equalsIgnoreCase(urlToSearch)) {
+                log.info("Found the URL {} in Spider Queue", urlToSearch);
+                return true;
+            }
+        }
+        log.info("URL {} is NOT found in Spider Queue", urlToSearch);
+        return false;
+    }
+
+    public Set<String> getUrls() {
+        return map.keySet();
+    }
+
+    private IHttpRequestResponse[] getQueue(String url) {
+        return map.get(url);
+    }
+
+    public void clear() {
+        map.clear();
+    }
+
+
+    private boolean compareSiteMap(IHttpRequestResponse[] newSiteMap, IHttpRequestResponse[] oldSiteMap){
+        if(newSiteMap.length != oldSiteMap.length) return false;
+
+        boolean sameSiteMap = true;
+        for(int i = 0; i < newSiteMap.length; i++) {
+            if(!Arrays.equals(newSiteMap[i].getRequest(), oldSiteMap[i].getRequest()) || !Arrays.equals(newSiteMap[i].getResponse(), oldSiteMap[i].getResponse())){
+                sameSiteMap = false;
+            }
+        }
+        return sameSiteMap;
+    }
+
+    public int getPercentageComplete() {
+        if (map.keySet().size() == 0) {
+            log.info("Spider Queue is empty. Returning the Percent Complete as 100%.");
+            return 100;
+        }
+
+        // Forcing a delay while spidering is working in another thread, before comparing siteMaps
+        try {
+            Thread.sleep(timeBetweenChecks);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        int totalPercentCompletion = 0;
+        for (String url : map.keySet()) {
+            IHttpRequestResponse[] httpMessageListOld = map.get(url);
+            IHttpRequestResponse[] httpMessageListNew = BurpExtender.getInstance().getCallbacks().getSiteMap(url);
+
+            if(compareSiteMap(httpMessageListNew, httpMessageListOld)){
+                totalPercentCompletion += 100;
+            }else{
+                totalPercentCompletion += 0;
+            }
+        }
+
+        map.replaceAll((url, v) -> BurpExtender.getInstance().getCallbacks().getSiteMap(url));
+
+        if(totalPercentCompletion > 0) {
+            int percentComplete = totalPercentCompletion / map.size();
+            log.info("Scan Percent Complete: {}", percentComplete);
+            return percentComplete;
+        }else{
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -166,6 +166,32 @@ public class BurpController {
       burp.excludeFromScope(url);
    }
 
+   @ApiOperation(value = "Send a base url to Burp Scanner to perform a passive scan", notes = "Scans through Burp Sitemap and sends all HTTP requests/responses with url starting with baseUrl to Burp Scanner for passive scan.")
+   @ApiImplicitParams({
+           @ApiImplicitParam(name = "baseUrl", value = "Base Url to submit for Passive scan.", required = true, dataType = "string", paramType = "query")
+   })
+   @ApiResponses(value = {
+           @ApiResponse(code = 200, message = "Success"),
+           @ApiResponse(code = 400, message = "Bad Request"),
+           @ApiResponse(code = 409, message = "Conflict"),
+           @ApiResponse(code = 500, message = "Failure")
+   })
+   @RequestMapping(method = POST, value = "/scanner/scans/passive")
+   public void scanPassive(@RequestParam(value = "baseUrl") String baseUrl)
+           throws MalformedURLException {
+      if (StringUtils.isEmpty(baseUrl)) {
+         throw new IllegalArgumentException("The 'baseUrl' parameter in payload must not be null or empty.");
+      }
+
+      boolean inScope = burp.isInScope(baseUrl);
+      log.info("Is {} in Scope: {}", baseUrl, inScope);
+      if (!inScope) {
+         log.info("Scan is NOT performed as the {} URL is not in scope.", baseUrl);
+         throw new IllegalStateException("The 'baseUrl' is NOT in scope. Set the 'baseUrl' scope to true before retry.");
+      }
+
+      burp.scan(baseUrl,false);
+   }
 
    @ApiOperation(value = "Send a base url to Burp Scanner to perform active scan", notes = "Scans through Burp Sitemap and sends all HTTP requests with url starting with baseUrl to Burp Scanner for active scan.")
    @ApiImplicitParams({
@@ -178,7 +204,7 @@ public class BurpController {
          @ApiResponse(code = 500, message = "Failure")
    })
    @RequestMapping(method = POST, value = "/scanner/scans/active")
-   public void scan(@RequestParam(value = "baseUrl") String baseUrl)
+   public void scanActive(@RequestParam(value = "baseUrl") String baseUrl)
          throws MalformedURLException {
       if (StringUtils.isEmpty(baseUrl)) {
          throw new IllegalArgumentException("The 'baseUrl' parameter in payload must not be null or empty.");
@@ -191,7 +217,7 @@ public class BurpController {
          throw new IllegalStateException("The 'baseUrl' is NOT in scope. Set the 'baseUrl' scope to true before retry.");
       }
 
-      burp.scan(baseUrl);
+      burp.scan(baseUrl,true);
    }
 
    @ApiOperation(value = "Deletes the active scan queue map from memory", notes = "Deletes the scan queue map from memory, not from Burp suite UI.")
@@ -250,11 +276,23 @@ public class BurpController {
          @ApiResponse(code = 500, message = "Failure")
    })
    @RequestMapping(method = GET, value = "/scanner/status")
-   public ScanProgress percentComplete() {
+   public ScanProgress scanPercentComplete() {
       ScanProgress scanProgress = new ScanProgress();
-      scanProgress.setTotalScanPercentage(burp.getPercentageComplete());
+      scanProgress.setTotalScanPercentage(burp.getScanPercentageComplete());
       return scanProgress;
    }
+
+    @ApiOperation(value = "Get the status of the spider", notes = "Returns an estimate of the current status of the spider. Due to the current limitations in Burp's Extender API, this endpoint will return 100% whenever the spider is no longer discovering new resources. On newer Burp APIs, we expect to be able to provide discrete values.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Success", response = SpiderProgress.class),
+            @ApiResponse(code = 500, message = "Failure")
+    })
+    @RequestMapping(method = GET, value = "/spider/status")
+    public SpiderProgress spiderPercentComplete() {
+        SpiderProgress spiderProgress = new SpiderProgress();
+        spiderProgress.setTotalSpiderPercentage(burp.getSpiderPercentageComplete());
+        return spiderProgress;
+    }
 
    @ApiOperation(value = "Send a seed url to Burp Spider", notes = "Sends a seed URL to the Burp Spider tool. The baseUrl should be in Suite-wide scope for the Spider to run..")
    @ApiImplicitParams({

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,4 +7,4 @@ headless:
 burp:
   edition: pro
 
-build.version: 1.0.2
+build.version: 1.0.3


### PR DESCRIPTION
This PR contains the following changes:

- Support for Burp _Scanner Passive_
- Experimental Support for _Spider Status_ (see https://github.com/vmware/burp-rest-api/issues/35)
Returns an estimate of the current status of the spider. Due to the current limitations in Burp's Extender API, this endpoint will return 100% whenever the spider is no longer discovering new resources
- Fixes/Improvements for _/burp/scanner/status_