### PR TITLE
Improved sitemap model: method/param/header/cookie

### DIFF
--- a/src/main/java/com/vmware/burp/extension/domain/Cookie.java
+++ b/src/main/java/com/vmware/burp/extension/domain/Cookie.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.vmware.burp.extension.domain;
+
+import burp.ICookie;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Date;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Cookie {
+
+   @XmlElement(required=true)
+   private String domain;
+
+   @XmlElement(required=true)
+   private Date expiration;
+
+   @XmlElement(required=true)
+   private String name;
+
+   @XmlElement(required=true)
+   private String path;
+
+   @XmlElement(required=true)
+   private String value;
+
+   private Cookie() {
+
+   }
+
+   public Cookie(ICookie iCookie) {
+      this.domain = iCookie.getDomain();
+      this.expiration = iCookie.getExpiration();
+      this.name = iCookie.getName();
+      this.path = iCookie.getPath();
+      this.value = iCookie.getValue();
+   }
+
+   public String getDomain() {
+      return domain;
+   }
+
+   public void setDomain(String domain) {
+      this.domain = domain;
+   }
+
+   public Date getExpiration() {
+      return expiration;
+   }
+
+   public void setExpiration(Date expiration) {
+      this.expiration = expiration;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   public String getPath() {
+      return path;
+   }
+
+   public void setPath(String path) {
+      this.path = path;
+   }
+
+   public String getValue() {
+      return value;
+   }
+
+   public void setValue(String value) {
+      this.value = value;
+   }
+}

--- a/src/main/java/com/vmware/burp/extension/domain/Parameter.java
+++ b/src/main/java/com/vmware/burp/extension/domain/Parameter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.vmware.burp.extension.domain;
+
+import burp.IParameter;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.net.URLDecoder;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Parameter {
+
+   @XmlElement(required=true)
+   private String name;
+   
+   @XmlElement(required=true)
+   private String value;
+
+   @XmlElement(required=true)
+   private ParameterType type;
+
+   private Parameter() {
+
+   }
+
+   public Parameter(IParameter iParameter) {
+      this.name = URLDecoder.decode(iParameter.getName());
+      this.value = URLDecoder.decode(iParameter.getValue());
+      this.type = ParameterType.getEnum(iParameter.getType());
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   public String getValue() {
+      return value;
+   }
+
+   public void setValue(String value) {
+      this.value = value;
+   }
+
+   public ParameterType getType() {
+      return type;
+   }
+
+   public void setType(ParameterType type) {
+      this.type = type;
+   }
+}

--- a/src/main/java/com/vmware/burp/extension/domain/ParameterType.java
+++ b/src/main/java/com/vmware/burp/extension/domain/ParameterType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.vmware.burp.extension.domain;
+
+import burp.IParameter;
+
+public enum ParameterType {
+   PARAM_BODY(IParameter.PARAM_BODY),
+   PARAM_COOKIE(IParameter.PARAM_COOKIE),
+   PARAM_JSON(IParameter.PARAM_JSON),
+   PARAM_MULTIPART_ATTR(IParameter.PARAM_MULTIPART_ATTR),
+   PARAM_URL(IParameter.PARAM_URL),
+   PARAM_XML(IParameter.PARAM_XML),
+   PARAM_XML_ATTR(IParameter.PARAM_XML_ATTR);
+
+   private byte parameterType;
+
+   private ParameterType(byte parameterType) {
+      this.parameterType = parameterType;
+   }
+
+   private byte getValue() {
+       return parameterType;
+   }
+
+   public static ParameterType getEnum(byte type) {
+       for (ParameterType parameterType : values()) {
+          if (parameterType.getValue() == type) {
+             return parameterType;
+          }
+       }
+       throw new IllegalArgumentException();
+   }
+}


### PR DESCRIPTION
The site map model was inconsistent in terms of identifying a
particulare request, because the request's method was missing.
Also, other useful information that burp provides to its extensions was
not included.

To solve this, the following information was added to the site map model:
* request method
* request parameters
* response headers
* response cookies

For that purpose, the following properties including getters and
setters were added to the class HttpMessage:
* String method
* List<String> headers
* List<Cookie> cookies
* List<Parameter> parameters

The new classes Cookie and Parameter hold the values provided by the
burp interfaces ICookie and IParameter. The enum ParameterType holds the
static byte values of IParameter that represent the type of a parameter.

Resolves #43