### PR TITLE
Limit scanning to the scope

### DIFF
--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -188,23 +188,28 @@ public class BurpService {
                 if(url.getPort() == url.getDefaultPort()) {
                     url = new URL(url.getProtocol(), url.getHost(), url.getFile());
                 }
-				boolean useHttps = url.getProtocol().equalsIgnoreCase("HTTPS");
-				if(isActive) {
-					//Trigger Burp's Active Scan
-					log.debug("Submitting Active Scan for the URL {}", url.toExternalForm());
-					IScanQueueItem iScanQueueItem = BurpExtender.getInstance().getCallbacks()
-							.doActiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
-									iHttpRequestResponse.getRequest());
-					scans.addItem(url.toExternalForm(), iScanQueueItem);
-				}else{
-					//Trigger Burp's Passive Scan
-					log.debug("Submitting Passive Scan for the URL {}", url.toExternalForm());
-					if (iHttpRequestResponse.getResponse() != null) {
-						BurpExtender.getInstance().getCallbacks()
-								.doPassiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
-										iHttpRequestResponse.getRequest(), iHttpRequestResponse.getResponse());
-					}
-				}                
+                // check if the url from the sitemap is still in scope (checking exceptions to scope)
+                if(isInScope(url.toExternalForm())){
+                    boolean useHttps = url.getProtocol().equalsIgnoreCase("HTTPS");
+                    if(isActive) {
+                        //Trigger Burp's Active Scan
+                        log.debug("Submitting Active Scan for the URL {}", url.toExternalForm());
+                        IScanQueueItem iScanQueueItem = BurpExtender.getInstance().getCallbacks()
+                                .doActiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
+                                        iHttpRequestResponse.getRequest());
+                        scans.addItem(url.toExternalForm(), iScanQueueItem);
+                    }else{
+                        //Trigger Burp's Passive Scan
+                        log.debug("Submitting Passive Scan for the URL {}", url.toExternalForm());
+                        if (iHttpRequestResponse.getResponse() != null) {
+                            BurpExtender.getInstance().getCallbacks()
+                                    .doPassiveScan(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort(), useHttps,
+                                            iHttpRequestResponse.getRequest(), iHttpRequestResponse.getResponse());
+                        }
+                    }
+                } else {
+                    log.info("URL {} not submitted to scan, since it matches a scope exception", url.toExternalForm());
+                }               
             }
             return true;
         } else {
@@ -290,3 +295,4 @@ public class BurpService {
         BurpExtender.getInstance().getCallbacks().exitSuite(promptUser);
     }
 }
+


### PR DESCRIPTION
Currently the scope method is simply getting URLs from the sitemap, and checking whether the baseUrl is within scope.
However, this is insufficient, due to the exceptions that may exist to the scope, such as certain paths or file extensions that are excluded (e.g. *.png, *.css, and so on).

Example:
Scope baseURL: http://example.org/
Exceptions: *.css and /criticalscriptthatdropsdatabases.cgi

Scanner will scan http://example.org/thisisatyle.css and http://example.org/criticalscriptthatdropsdatabases.cgi if they are in the sitemap (spider does not touch them, but lists them in the sitemap, although grayed out in the UI).

This PR checks for each URL in the sitemap if it is still within scope, and prevents those from being sent to the scanner (either active or passive) if it is not.