### PR TITLE
Fix for #50

### DIFF
--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -71,10 +71,9 @@ public class BurpService {
 
         //Project Data File
         //Note: Burp Free does not support project data files
-        if (!args.containsOption(PROJECT_FILE) && !burpEdition.equalsIgnoreCase("free")) {
+        if (!burpEdition.equalsIgnoreCase("free") || !args.containsOption(PROJECT_FILE) {
             projectData = new String[]{generateProjectDataTempFile()};
         } else {
-
             projectData = args.getOptionValues(PROJECT_FILE).stream().toArray(String[]::new);
             for( int i = 0; i < projectData.length; i++) {
                 projectData[i] = PROJECT_FILE_ARGUMENT + projectData[i];


### PR DESCRIPTION
This should resolve the issue described by: #50 

Cause
---
Use of AND condition instead of OR condition means that user must be using a free Burp version AND have also not specified a project file.

However, this ignores two cases:
1. The user mistakenly states a project file with Burp free edition
2. The user does not state a project file with Burp paid edition

Both of these cases require the creation of an empty projectData array.

Resolution
---
Changed conditional operator from `&&` to `||`.

I also rearranged the operands so that the `Note:` line flows into the logic of the if-statement. 
"Burp Free does not support project..." => "`if (!burpEdition.equalsIgnoreCase('free')`"