### PR TITLE
Better Fix #50 and #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ or
 ```
     gradlew bootRun -Dheadless.mode=false
 ```
-
+or with the `bootRun` command using the `-PappArgs` to pass args directly to burp suite :
+```
+    gradlew bootRun -PappArgs="['-Djava.awt.headless=false','--project-file=./test.burp']"
+```
 With the executable JAR:
 ```
     java -jar burp-rest-api-1.0.2.jar -Djava.awt.headless=false

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,10 @@ task createschemaTargetDir () {
 
 bootRun {
     // support passing -Dsystem.property=value to bootRun task
+    //support passing -PappArgs="['arg1']" ex : gradlew bootRun -PappArgs="['--project-file=/test/tes.burp']"
+     if (project.hasProperty("appArgs")) {
+        args Eval.me(appArgs)
+    }
     systemProperties = System.properties
 
     if (System.getProperty('DEBUG', 'false') == 'true') {

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -76,9 +76,13 @@ public class BurpService {
                 projectData[i] = PROJECT_FILE_ARGUMENT + projectData[i];
             }
         } else { 
-		//Note: Burp Free does not support project data files
+	//Note: Burp Free does not support project data files
+            if(!burpEdition.equalsIgnoreCase("free")){
                        projectData = new String[]{generateProjectDataTempFile()};
-        } 
+                       } else {
+                           projectData = new String[]{};
+                       }
+        }  
 
         //Project Options File
         if (!args.containsOption(CONFIG_FILE)) {

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -70,15 +70,15 @@ public class BurpService {
         String[] userOptions;
 
         //Project Data File
-        //Note: Burp Free does not support project data files
-        if (!burpEdition.equalsIgnoreCase("free") || !args.containsOption(PROJECT_FILE)) {
-            projectData = new String[]{generateProjectDataTempFile()};
-        } else {
-            projectData = args.getOptionValues(PROJECT_FILE).stream().toArray(String[]::new);
+       if (burpEdition.equalsIgnoreCase("pro") && args.containsOption(PROJECT_FILE)) {
+			 projectData = args.getOptionValues(PROJECT_FILE).stream().toArray(String[]::new);
             for( int i = 0; i < projectData.length; i++) {
                 projectData[i] = PROJECT_FILE_ARGUMENT + projectData[i];
             }
-        }
+        } else { 
+		//Note: Burp Free does not support project data files
+                       projectData = new String[]{generateProjectDataTempFile()};
+        } 
 
         //Project Options File
         if (!args.containsOption(CONFIG_FILE)) {

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -70,19 +70,15 @@ public class BurpService {
         String[] userOptions;
 
         //Project Data File
-       if (burpEdition.equalsIgnoreCase("pro") && args.containsOption(PROJECT_FILE)) {
-			 projectData = args.getOptionValues(PROJECT_FILE).stream().toArray(String[]::new);
+        //Note: Burp Free does not support project data files
+        if (!burpEdition.equalsIgnoreCase("free") || !args.containsOption(PROJECT_FILE)) {
+            projectData = new String[]{generateProjectDataTempFile()};
+        } else {
+            projectData = args.getOptionValues(PROJECT_FILE).stream().toArray(String[]::new);
             for( int i = 0; i < projectData.length; i++) {
                 projectData[i] = PROJECT_FILE_ARGUMENT + projectData[i];
             }
-        } else { 
-	//Note: Burp Free does not support project data files
-            if(!burpEdition.equalsIgnoreCase("free")){
-                       projectData = new String[]{generateProjectDataTempFile()};
-                       } else {
-                           projectData = new String[]{};
-                       }
-        }  
+        }
 
         //Project Options File
         if (!args.containsOption(CONFIG_FILE)) {


### PR DESCRIPTION
Adds : 
- `-PappArgs="['arg1','arg2','arg3']"` to be able to pass arguments to burp suite directly via the gradle wrapper ( `gradlew bootRun -PappArgs="['--project-file=./test.burp','--config-file=./cfg.json','--user-config-file=./usr-cfg.json']"` ).
- Fixed #46 by changing what #52 introduced by changing the negative assertions to positive assertions and and making the logical operator back to `&&`