### PR TITLE
Fix wrong logic on adding project file

### DIFF
--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -71,7 +71,7 @@ public class BurpService {
 
         //Project Data File
         //Note: Burp Free does not support project data files
-        if (!burpEdition.equalsIgnoreCase("free") || !args.containsOption(PROJECT_FILE)) {
+        if (burpEdition.equalsIgnoreCase("free") || !args.containsOption(PROJECT_FILE)) {
             projectData = new String[]{generateProjectDataTempFile()};
         } else {
             projectData = args.getOptionValues(PROJECT_FILE).stream().toArray(String[]::new);


### PR DESCRIPTION
Me as burp pro user wondering why i cannot pass --project-file parameter. When I saw this code, this is totally wrong. So I fix this and the logic will be

```
if (BurpFreeEdition or there's no project-file option) {
//generate project temp file
} else {
//use project file that supplied through argument
}

Please accept this PR so burpsuite pro user will not get confused 
