### PR TITLE
Deprecating support for Burp Free / Burp Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,22 @@ Upon successfully building the project, an executable JAR file is created with t
 
 ### Build & Run
 
-1. [Download](https://portswigger.net/burp/download.html) the Professional edition of Burp Suite. You _may_ use Free edition but capabilities are limited.
+1. [Download](https://portswigger.net/burp/download.html) the Professional edition of Burp Suite.
 2. Create a `lib` folder under the project directory and place the Burp Suite JAR file into it and rename it to "burpsuite_pro.jar".
 3. The project can be run either by running the Gradle Spring `bootRun` command or by directly launching the JAR
  created from building the project:
 
 ```
-    gradlew bootRun # for pro edition, or
-    gradlew bootRun "-Dburp.edition=free" # for free edition
+    gradlew bootRun
 ```
 
 or
 
 ```
-    # build the jar (note that testing phase will fail if you provide free edition jar in ./lib)
+    # build the jar
     gradlew clean build
     # and run it
-    java -jar build/libs/burp-rest-api-1.0.2.jar # for pro edition, or
-    java -jar build/libs/burp-rest-api-1.0.2.jar --burp.edition=free # for free edition
+    java -jar build/libs/burp-rest-api-1.0.2.jar
 ```
 The version number of the JAR should match the version number from `build.gradle` while generating the JAR.
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'eclipse'
 apply plugin: 'spring-boot'
 
 final def extensionName = 'burp-rest-api'
-version = '1.0.3'
+version = '1.0.4'
 
 def updateVersion() {
     def configFile = new File('src/main/resources/application.yml')

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -56,22 +56,21 @@ public class BurpService {
     private String version;
 
     @Autowired
-    public BurpService(ApplicationArguments args, @Value("${headless.mode}") boolean headlessMode, @Value("${burp.edition}") String burpEdition)
+    public BurpService(ApplicationArguments args, @Value("${headless.mode}") boolean headlessMode)
             throws IOException {
         if (!headlessMode) {
             log.info("Setting java.awt.headless to false...");
             System.setProperty("java.awt.headless", Boolean.toString(false));
         }
         log.info("# of command line arguments received to Burp suite: {}", args.getSourceArgs().length);
-        log.info("Launching the Burp suite ({} edition) in {} mode...", burpEdition, headlessMode ? "headless" : "UI");
+        log.info("Launching Burp suite in {} mode...", headlessMode ? "headless" : "UI");
 
         String[] projectData;
         String[] projectOptions;
         String[] userOptions;
 
         //Project Data File
-        //Note: Burp Free does not support project data files
-        if (!burpEdition.equalsIgnoreCase("free") || !args.containsOption(PROJECT_FILE)) {
+        if (!args.containsOption(PROJECT_FILE)) {
             projectData = new String[]{generateProjectDataTempFile()};
         } else {
             projectData = args.getOptionValues(PROJECT_FILE).stream().toArray(String[]::new);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,4 @@ server:
 headless:
   mode: ${java.awt.headless}
 
-burp:
-  edition: pro
-
-build.version: 1.0.3
+build.version: 1.0.4

--- a/src/test/java/com/vmware/burp/extension/client/BurpClientIT.java
+++ b/src/test/java/com/vmware/burp/extension/client/BurpClientIT.java
@@ -58,6 +58,7 @@ public class BurpClientIT {
     @Before
     public void setUp() {
         burpClient = new BurpClient("http://localhost:" + port);
+        log.info("!! Make sure that there are no applications configured to use the proxy !!");
     }
 
     @Test
@@ -104,7 +105,7 @@ public class BurpClientIT {
     }
 
     @Test
-    public void testScopeMethods() throws UnsupportedEncodingException {
+    public void testScopeMethods() {
         String httpBaseUrl = "http://source.vmware.com";
         String httpsBaseUrl = "https://source.vmware.com";
 
@@ -147,7 +148,7 @@ public class BurpClientIT {
 
     private void sendRequestThruProxy() throws IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
 
-        SSLContext sslContext = null;
+        SSLContext sslContext;
         sslContext = SSLContexts.custom().loadTrustMaterial((chain, authType) -> true).build();
 
         SSLConnectionSocketFactory sslConnectionSocketFactory =
@@ -157,7 +158,7 @@ public class BurpClientIT {
 
         try (CloseableHttpClient httpClient = HttpClients.custom()
                 .setSSLSocketFactory(sslConnectionSocketFactory)
-                .build();) {
+                .build()) {
             HttpHost target = new HttpHost(BurpClientIT.TARGET_HOST);
             HttpHost proxy = new HttpHost(PROXY_HOST, PROXY_PORT, PROXY_SCHEME);
 


### PR DESCRIPTION
As discussed with the original maintainers, I am deprecating the support for Burp Free / Burp Community.
Considering the exposed functionalities (see below), this extension has no use with Burp Free. Most of the operations are related to web scanning automation, which is not available in Burp Free/Community. 

Over the course of the past years, this option has created confusion between users as some people expected this extension to be able to fully operate with the Free edition. 

![screen shot 2018-10-23 at 20 38 43](https://user-images.githubusercontent.com/6027823/47385816-583ffa00-d70b-11e8-80a9-1d07a72b8edc.png)
