### PR TITLE
Bug fixes, and minor improvements ahead of major release bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The version number of the JAR should match the version number from `build.gradle
 
 ### Configuration
 
-By default, Burp is launched in headless mode with the Proxy running on port 8080/tcp and the REST endpoint running on 8090/tcp.
+By default, Burp is launched in headless mode with the Proxy running on port 8080/tcp (localhost only) and the REST endpoint running on 8090/tcp (localhost only).
 
 To __run Burp in UI mode__ from the command line, use one of the following commands:
 
@@ -88,12 +88,26 @@ or
     java -jar burp-rest-api-1.0.2.jar --port=8081
 ```
 
+You can also __modify the server address__, used for network address binding:
+
+With the `bootRun` command:
+```
+    gradlew bootRun -Dserver.address=192.168.1.2
+```
+or
+```
+    gradlew bootRun -Daddress=192.168.1.2
+```
+
 ### Command Line Arguments
 
 The following command line arguments are used only by the extension to configure the run mode and port number.
 
 `--server.port=<port_number>` : The REST API endpoint is available at the given port number. `--port=<port_number>`
  works as short hand argument.
+ 
+ `--server.address=<network address>` : Network address to which the REST API endpoint should bind. `--address=<address_ip>`
+  works as short hand argument.
 
 `--headless.mode=<true/false>` : When set to false, runs Burp Suite in UI mode. Otherwise runs Burp Suite in headless
  mode. Default value: System Property (java.awt.headless)

--- a/src/main/java/com/vmware/burp/extension/domain/HttpMessage.java
+++ b/src/main/java/com/vmware/burp/extension/domain/HttpMessage.java
@@ -27,7 +27,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-@JsonIgnoreProperties(value = { "request", "response" })
+//Returning full HTTP request and response
+//@JsonIgnoreProperties(value = { "request", "response" })
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonInclude(Include.NON_NULL)

--- a/src/main/java/com/vmware/burp/extension/domain/internal/SpiderQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/SpiderQueueMap.java
@@ -99,7 +99,7 @@ public class SpiderQueueMap {
 
         if(totalPercentCompletion > 0) {
             int percentComplete = totalPercentCompletion / map.size();
-            log.info("Scan Percent Complete: {}", percentComplete);
+            log.info("Spider Percent Complete: {}", percentComplete);
             return percentComplete;
         }else{
             return 0;

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -74,7 +74,7 @@ public class BurpService {
             projectData = new String[]{generateProjectDataTempFile()};
         } else {
             projectData = args.getOptionValues(PROJECT_FILE).stream().toArray(String[]::new);
-            for( int i = 0; i < projectData.length; i++) {
+            for(int i = 0; i < projectData.length; i++) {
                 projectData[i] = PROJECT_FILE_ARGUMENT + projectData[i];
             }
         }
@@ -84,7 +84,7 @@ public class BurpService {
             projectOptions = new String[]{generateProjectOptionsTempFile()};
         } else {
             projectOptions = args.getOptionValues(CONFIG_FILE).stream().toArray(String[]::new);
-            for( int i = 0; i < projectOptions.length; i++) {
+            for(int i = 0; i < projectOptions.length; i++) {
                 projectOptions[i] = CONFIG_FILE_ARGUMENT + projectOptions[i];
             }
         }
@@ -94,7 +94,7 @@ public class BurpService {
             userOptions = new String[]{generateUserOptionsTempFile()};
         } else {
             userOptions = args.getOptionValues(USER_CONFIG_FILE).stream().toArray(String[]::new);
-            for( int i = 0; i < userOptions.length; i++) {
+            for(int i = 0; i < userOptions.length; i++) {
                 userOptions[i] = USER_CONFIG_FILE_ARGUMENT + userOptions[i];
             }
         }
@@ -143,9 +143,14 @@ public class BurpService {
         return PROJECT_FILE_ARGUMENT + projectTempDir.toAbsolutePath() + File.separator + TEMPORARY_PROJECT_FILE_NAME;
     }
 
-    public String getConfigAsJson() {
-        log.info("Retrieving the Burp Configuration...");
-        return BurpExtender.getInstance().getCallbacks().saveConfigAsJson();
+    public String getConfigAsJson(String configPaths) {
+        if (configPaths != null) {
+            log.info("Retrieving the Burp Configuration for configPaths: " + configPaths);
+            return BurpExtender.getInstance().getCallbacks().saveConfigAsJson(configPaths);
+        } else {
+            log.info("Retrieving the Burp Configuration with empty configPaths");
+            return BurpExtender.getInstance().getCallbacks().saveConfigAsJson();
+        }
     }
 
     public String getBurpVersion() {

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -58,12 +58,23 @@ public class BurpController {
 
    @ApiOperation(value = "Get Burp suite project-level configuration", notes = "Burp suite project-level configuration is returned as JSON.")
    @ApiResponses(value = {
-         @ApiResponse(code = 200, message = "Success", response = JsonNode.class),
-         @ApiResponse(code = 500, message = "Failure")
+           @ApiResponse(code = 200, message = "Success", response = JsonNode.class),
+           @ApiResponse(code = 500, message = "Failure")
    })
    @RequestMapping(method = GET, value = "/configuration")
    public JsonNode getConfiguration() throws IOException {
-      String configuration = burp.getConfigAsJson();
+      String configuration = burp.getConfigAsJson("");
+      return new ObjectMapper().readTree(configuration);
+   }
+
+   @ApiOperation(value = "Get Burp suite project-level configuration with provided configuration path", notes = "Burp suite project-level configuration returned as JSON, from the given configuration path (e.g. 'proxy.request_listeners')")
+   @ApiResponses(value = {
+           @ApiResponse(code = 200, message = "Success", response = JsonNode.class),
+           @ApiResponse(code = 500, message = "Failure")
+   })
+   @RequestMapping(method = POST, value = "/configuration")
+   public JsonNode getConfiguration(@RequestBody String configAsJson) throws IOException {
+      String configuration = burp.getConfigAsJson(configAsJson);
       return new ObjectMapper().readTree(configuration);
    }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,10 @@
 server:
+  address: ${address:127.0.0.1}
   port: ${port:8090}
+  compression:
+    enabled: true
+    min-response-size: 1024
+    mime-types: '*/*'
 
 headless:
   mode: ${java.awt.headless}


### PR DESCRIPTION
This PR is meant to resolve a bunch of standing issues, ahead of our major release bump.

In particular, the following changes have been made:

- Support for API address binding (by default, it's now binding on localhost only)
- _HttpMessage_ now returns the full HTTP request/response as base64. To reduce response size and overall response time, compression has been enabled by default for requests over 1024 bytes
- getConfigAsJson support for given configuration paths (e.g. 'proxy.request_listeners' to simply get the configuration regarding listeners)