### PR TITLE
2ndgen extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ bin/
 lib/burpsuite_pro*.jar
 lib/burpsuite_free*.jar
 lib/burpsuite_community*.jar
+
+# Avoid committing generated files
+src/main/resources/static/*.jar

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,51 @@
+FAQ
+===
+
+Is Burp Suite Free/Community edition supported?
+-----------------------------------------------
+
+No, it is not. Burp Rest API exposes functionalities that are best suited for the Professional 
+version of Burp Suite. Even if it was possible to start _burp-rest-api_ using the Free version of Burp, this is no longer possible and the support won't be included in future releases.
+
+Whenever I run the gradle command I receive an error. What can be the the cause?
+----------------------------------------------------------------------------
+
+Often times, Gradle introduces incompatibility between major versions, therefore
+the recommended way of executing any Gradle build is by using the Gradle
+Wrapper (in short just “Wrapper”). The Wrapper is a script that invokes a
+declared version of Gradle, downloading it beforehand if necessary.
+
+See [Issue 37](https://github.com/vmware/burp-rest-api/issues/37).
+
+Is it possible to run burp-rest-api graphically in remote servers?
+------------------------------------------------------------------
+
+Yes, it is possible to run Burp in graphical environments in multiple
+configurations (X Forwarding, Full VNC, RDP, XPRA).
+
+For running a non persistent X Forwarding session on your OS you can follow this
+[guide](https://uisapp2.iu.edu/confluence-prd/pages/viewpage.action?pageId=280461906).
+
+See [Issue 60](https://github.com/vmware/burp-rest-api/issues/60).
+
+Is it possible to customize the binding address:port for Burp Proxy and/or burp-rest-api APIs?
+----------------------------------------------------------------------------------------------
+
+There are two binding ports in a standard burp-rest-api setup:
+- **burp-rest-api RPC mechanism**. Both IP address and port can be customized at runtime using command line arguments (namely _--server.address_ and _--server.port_)
+- **Burp Proxy Listener**. This is a Burp Suite configuration, and can be customized using a custom project option file.
+
+```
+        "request_listeners":[
+            {
+                "certificate_mode":"per_host",
+                "listen_mode":"192.168.1.1",
+                "listener_port":8080,
+                "running":true
+            }
+```
+
+Is Burp Suite v2 supported?
+----------------------------------------------------------------------------------------------
+
+Next generation Burp Suite v2 is a beta release at the time of writing this FAQ. While we will *try* to mantain support for both Burp Suite stable and beta, we cannot ensure full compability. For production, please stay on Burp Suite Professional stable branch.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018 Doyensec LLC. All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  following conditions are met: Redistributions of source code must retain the above copyright notice, this list of

--- a/README.md
+++ b/README.md
@@ -4,104 +4,54 @@
 
 A REST/JSON API to the Burp Suite security tool.
 
-Upon successfully building the project, an executable JAR file is created with the Burp Suite Professional JAR bundled
- in it. When the JAR is launched, it provides a REST/JSON endpoint to access the Scanner, Spider, Proxy and other
- features of the Burp Suite Professional security tool.
-
-## Try it out
-
-### Prerequisites
-
-* Java 8
-* Gradle
-* Licensed Burp Suite Professional version 1.7.x or later from: <http://portswigger.net/burp/>
-
-
-### Build & Run
-
-1. [Download](https://portswigger.net/burp/download.html) the Professional edition of Burp Suite.
-2. Create a `lib` folder under the project directory and place the Burp Suite JAR file into it and rename it to "burpsuite_pro.jar".
-3. The project can be run either by running the Gradle Spring `bootRun` command or by directly launching the JAR
- created from building the project:
-
-```
-    gradlew bootRun
-```
-
-or
-
-```
-    # build the jar
-    gradlew clean build
-    # and run it
-    java -jar build/libs/burp-rest-api-*.jar --burp.jar=./lib/burpsuite_pro.jar 
-```
-The version number of the JAR should match the version number from `build.gradle` while generating the JAR.
+Since version 2.0.0 it is possible to run the burp-rest-api release jar,
+downloading it directly from the 
+[release channel](https://github.com/vmware/burp-rest-api/releases).
 
 ## Documentation
 
 ### Configuration
 
-By default, Burp is launched in headless mode with the Proxy running on port 8080/tcp (localhost only) and the REST endpoint running on 8090/tcp (localhost only).
+By default, Burp is launched in headless mode with the Proxy running on port 8080/tcp (**localhost only**) and the REST endpoint running on 8090/tcp (**localhost only**).
 
 To __run Burp in UI mode__ from the command line, use one of the following commands:
 
-With the `bootRun` command:
 ```
-    gradlew bootRun -Djava.awt.headless=false --burp.jar=./lib/burpsuite_pro.jar
-```
-or
-```
-    gradlew bootRun -Dheadless.mode=false --burp.jar=./lib/burpsuite_pro.jar
-```
-or with the `bootRun` command using the `-PappArgs` to pass args directly to burp suite :
-```
-    gradlew bootRun -PappArgs="['-Djava.awt.headless=false','--project-file=./test.burp']"
-```
-With the executable JAR:
-```
-    java -jar burp-rest-api-1.0.2.jar -Djava.awt.headless=false --burp.jar=./lib/burpsuite_pro.jar
+    java -jar burp-rest-api-2.0.0.jar -Djava.awt.headless=false --burp.jar=./lib/burpsuite_pro.jar
 ```
 or
 ```
-    java -jar burp-rest-api-1.0.2.jar --headless.mode=false --burp.jar=./lib/burpsuite_pro.jar
+    java -jar burp-rest-api-2.0.0.jar --headless.mode=false --burp.jar=./lib/burpsuite_pro.jar
 ```
 
 
 To __modify the server port__ on which the API is accessible, use one of the following commands:
 
-With the `bootRun` command:
 ```
-    gradlew bootRun -Dserver.port=8081 --burp.jar=./lib/burpsuite_pro.jar
-```
-or
-```
-    gradlew bootRun -Dport=8081 --burp.jar=./lib/burpsuite_pro.jar
-```
-
-With the executable JAR:
-```
-    java -jar burp-rest-api-1.0.2.jar --server.port=8081 --burp.jar=./lib/burpsuite_pro.jar
+    java -jar burp-rest-api-2.0.0.jar --server.port=8081 --burp.jar=./lib/burpsuite_pro.jar
 ```
 or
 ```
-    java -jar burp-rest-api-1.0.2.jar --port=8081 --burp.jar=./lib/burpsuite_pro.jar
+    java -jar burp-rest-api-2.0.0.jar --port=8081 --burp.jar=./lib/burpsuite_pro.jar
 ```
 
 You can also __modify the server address__, used for network address binding:
 
-With the `bootRun` command:
 ```
-    gradlew bootRun -Dserver.address=192.168.1.2
+    java -jar burp-rest-api-2.0.0.jar --server.address=192.168.1.2 --burp.jar=./lib/burpsuite_pro.jar
 ```
 or
 ```
-    gradlew bootRun -Daddress=192.168.1.2
+    java -jar burp-rest-api-2.0.0.jar --address=192.168.1.2 --burp.jar=./lib/burpsuite_pro.jar
 ```
 
 ### Command Line Arguments
 
 The following command line arguments are used only by the extension to configure the run mode and port number.
+
+`--burp.jar=<filaname.jar>` : Loads the Burp jar dinamically, and expose it through REST APIs. This flag is required.
+
+`--burp.ext=<filename.{jar,rb,py}` : Loads the given Burp extensions during application startup. This flag can be repeated.
 
 `--server.port=<port_number>` : The REST API endpoint is available at the given port number. `--port=<port_number>`
  works as short hand argument.
@@ -122,7 +72,7 @@ Command line arguments passed to the executable burp-rest-api JAR are forwarded 
 `--config-file=<filename>` : Opens the project using the options contained in the selected project configuration file. To
  load multiple project configurations, this argument can be passed more than once with different values.
  
- `--user-config-file=<filename>` : Opens the project using the options contained in the selected user configuration file. To
+`--user-config-file=<filename>` : Opens the project using the options contained in the selected user configuration file. To
   load multiple user configurations, this argument can be passed more than once with different values.
 
 For more information on Projects, refer to the Burp Suite documentation
@@ -155,18 +105,55 @@ This project also comes with a client (_BurpClient.java_) written in Java for us
 ## Credits
 
 This project is originally inspired from [Resty-Burp](https://github.com/continuumsecurity/resty-burp
- "continuumsecurity/resty-burp: REST/JSON interface to Burp Suite") and is developed in partnership with [Doyensec](https://www.doyensec.com).
+ "continuumsecurity/resty-burp: REST/JSON interface to Burp Suite"), and is developed in partnership with [Doyensec LLC](https://doyensec.com/). <img src="https://www.doyensec.com/images/logo.png" width="300">
 
 ## Contributing
 
 The burp-rest-api project team welcomes contributions from the community. If you wish to contribute code and you have
  not signed our contributor license agreement (CLA), our bot will update the issue when you open a Pull Request. For
- any questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq). For more detailed
- information, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
+ any questions about the CLA process, please refer to our [CLA FAQ](https://cla.vmware.com/faq). For more detailed
+ information, refer to [CONTRIBUTING.md](CONTRIBUTING.md) and [FAQ.md](FAQ.md).
+
+### Develop
+
+Upon successfully building the project, an executable JAR file is created.
+The Burp suite JAR can be loaded dinamically through the `--burp.jar=` argument.
+When the JAR is launched, it provides a REST/JSON endpoint to access the Scanner, Spider, Proxy and other
+ features of the Burp Suite Professional security tool.
+
+#### Prerequisites
+
+* Java 8
+* Gradle
+* Licensed Burp Suite Professional version 1.7.x or later from: <http://portswigger.net/burp/>
+
+
+#### Build & Run
+
+1. [Download](https://portswigger.net/burp/download.html) the Professional edition of Burp Suite.
+2. The project can be run either by running the Gradle Spring `bootRun` command or by directly launching the JAR
+ created from building the project:
+3. OPTIONAL: Create a `lib` folder under the project directory and place the Burp Suite JAR file into it and rename it to "burpsuite_pro.jar" in order to run the integration tests.
+
+```
+    ./gradlew bootRun --burp.jar=./lib/burpsuite_pro.jar
+```
+
+or
+
+```
+    # build the jar
+    ./gradlew clean build
+    # and run it
+    java -jar build/libs/burp-rest-api-2.0.0.jar --burp.jar=./lib/burpsuite_pro.jar 
+```
+The version number of the JAR should match the version number from `build.gradle` while generating the JAR.
+
 
 ## License
 
 Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+Copyright (c) 2018 Doyensec LLC. All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  following conditions are met: Redistributions of source code must retain the above copyright notice, this list of

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or
     # build the jar
     gradlew clean build
     # and run it
-    java -jar build/libs/burp-rest-api-1.0.2.jar
+    java -jar build/libs/burp-rest-api-*.jar --burp.jar=./lib/burpsuite_pro.jar 
 ```
 The version number of the JAR should match the version number from `build.gradle` while generating the JAR.
 
@@ -48,11 +48,11 @@ To __run Burp in UI mode__ from the command line, use one of the following comma
 
 With the `bootRun` command:
 ```
-    gradlew bootRun -Djava.awt.headless=false
+    gradlew bootRun -Djava.awt.headless=false --burp.jar=./lib/burpsuite_pro.jar
 ```
 or
 ```
-    gradlew bootRun -Dheadless.mode=false
+    gradlew bootRun -Dheadless.mode=false --burp.jar=./lib/burpsuite_pro.jar
 ```
 or with the `bootRun` command using the `-PappArgs` to pass args directly to burp suite :
 ```
@@ -60,11 +60,11 @@ or with the `bootRun` command using the `-PappArgs` to pass args directly to bur
 ```
 With the executable JAR:
 ```
-    java -jar burp-rest-api-1.0.2.jar -Djava.awt.headless=false
+    java -jar burp-rest-api-1.0.2.jar -Djava.awt.headless=false --burp.jar=./lib/burpsuite_pro.jar
 ```
 or
 ```
-    java -jar burp-rest-api-1.0.2.jar --headless.mode=false
+    java -jar burp-rest-api-1.0.2.jar --headless.mode=false --burp.jar=./lib/burpsuite_pro.jar
 ```
 
 
@@ -72,20 +72,20 @@ To __modify the server port__ on which the API is accessible, use one of the fol
 
 With the `bootRun` command:
 ```
-    gradlew bootRun -Dserver.port=8081
+    gradlew bootRun -Dserver.port=8081 --burp.jar=./lib/burpsuite_pro.jar
 ```
 or
 ```
-    gradlew bootRun -Dport=8081
+    gradlew bootRun -Dport=8081 --burp.jar=./lib/burpsuite_pro.jar
 ```
 
 With the executable JAR:
 ```
-    java -jar burp-rest-api-1.0.2.jar --server.port=8081
+    java -jar burp-rest-api-1.0.2.jar --server.port=8081 --burp.jar=./lib/burpsuite_pro.jar
 ```
 or
 ```
-    java -jar burp-rest-api-1.0.2.jar --port=8081
+    java -jar burp-rest-api-1.0.2.jar --port=8081 --burp.jar=./lib/burpsuite_pro.jar
 ```
 
 You can also __modify the server address__, used for network address binding:

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,17 @@ def updateVersion() {
     configFile.write(configContent, 'UTF-8')
 }
 
+sourceSets {
+    entrypoint {
+        java {
+            compileClasspath += main.output
+            runtimeClasspath += main.output
+        }
+    }
+}
+
+test.onlyIf { file('./lib/burpsuite_pro.jar').exists() }
+
 allprojects {
     //Display warning
     println " !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
@@ -55,19 +66,22 @@ targetCompatibility = 1.8
 File schemaTargetDir = new File('build/generated-schema')
 
 configurations {
-  jaxb
+    jaxb
     compile.exclude module: "spring-boot-starter-tomcat"
+    testCompile.extendsFrom entrypointCompile
+    testRuntime.extendsFrom entrypointRuntime
 }
 
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-web')
     compile("org.springframework.boot:spring-boot-starter-jetty")
-    compile fileTree(dir: 'lib', include: '**/*.jar')
     compile "io.springfox:springfox-swagger2:2.+"
     compile "io.springfox:springfox-swagger-ui:2.+"
-    
-    compile name: 'burpsuite_pro'
+    compileOnly "net.portswigger.burp.extender:burp-extender-api:1.7.22"
 
+    entrypointCompileOnly "net.portswigger.burp.extender:burp-extender-api:1.7.22"
+
+    testCompile fileTree(dir: 'lib', include: '**/*.jar')
     testCompile('org.springframework.boot:spring-boot-starter-test')
     testCompile('org.apache.httpcomponents:httpclient:4.5.2')
 
@@ -96,6 +110,20 @@ bootRun {
                 '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005'
     }
 }
+
+
+task entrypointJar(type: Jar) {
+    destinationDir = file("src/main/resources/static/")
+    from(sourceSets.entrypoint.output) {
+        include '**/*.class'
+    }
+    archiveName = 'rest-api.jar'
+}
+jar.dependsOn entrypointJar
+task deleteEntrypointOriginalJar(type: Delete) {
+    delete entrypointJar.archivePath.toString() + '.original'
+}
+assemble.dependsOn deleteEntrypointOriginalJar
 
 task extractApi(type: Copy) {
 	from(zipTree('build/libs/' + extensionName + '-' + version + '.jar'))

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'eclipse'
 apply plugin: 'spring-boot'
 
 final def extensionName = 'burp-rest-api'
-version = '1.0.4'
+version = '2.0.0'
 
 def updateVersion() {
     def configFile = new File('src/main/resources/application.yml')

--- a/src/entrypoint/java/burp/BurpExtender.java
+++ b/src/entrypoint/java/burp/BurpExtender.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Doyensec LLC.
+ */
+
+package burp;
+
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * burp.BurpExtender is the burp-rest-api 2nd-gen entrypoint.
+ *
+ * This class search for the burp.LegacyBurpExtender 1st-gen entrypoint in the default classpath in order to execute it
+ * through reflection. This is needed in order to made Burp able to load more than one extension at a time.
+ */
+public class BurpExtender implements IBurpExtender {
+    /**
+     * This method is invoked when the extension is loaded. It registers an
+     * instance of the
+     * <code>IBurpExtenderCallbacks</code> interface, providing methods that may
+     * be invoked by the extension to perform various actions.
+     *
+     * @param callbacks An
+     *                  <code>IBurpExtenderCallbacks</code> object.
+     */
+    @Override
+    public void registerExtenderCallbacks(IBurpExtenderCallbacks callbacks) {
+        try {
+            legacyRegisterExtenderCallbacks(callbacks);
+        } catch (Exception e) {
+            PrintWriter stderr = new PrintWriter(callbacks.getStderr(), true);
+            stderr.format("Exception: %s %s %s", e.getClass().getCanonicalName(), e.getCause(),  e.getMessage());
+        }
+    }
+
+    private static void legacyRegisterExtenderCallbacks(IBurpExtenderCallbacks callbacks)
+            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Class clazz = classLoader.loadClass("burp.LegacyBurpExtender");
+        Object obj = clazz.newInstance();
+        Method method = clazz.getMethod("registerExtenderCallbacks", IBurpExtenderCallbacks.class);
+        method.invoke(obj, callbacks);
+    }
+}

--- a/src/main/java/burp/LegacyBurpExtender.java
+++ b/src/main/java/burp/LegacyBurpExtender.java
@@ -6,15 +6,15 @@ import org.slf4j.LoggerFactory;
 import java.io.PrintWriter;
 
 /**
- * Copyright VMware, Inc. All rights reserved. -- VMware Confidential
+ * Copyright VMware, Inc. All rights reserved.
  */
-public class BurpExtender implements IBurpExtender {
-    private static final Logger log = LoggerFactory.getLogger(BurpExtender.class);
-    private static BurpExtender instance;
+public class LegacyBurpExtender implements IBurpExtender {
+    private static final Logger log = LoggerFactory.getLogger(LegacyBurpExtender.class);
+    private static LegacyBurpExtender instance;
     private IBurpExtenderCallbacks callbacks;
     private IExtensionHelpers helpers;
 
-    public static BurpExtender getInstance() {
+    public static LegacyBurpExtender getInstance() {
         return instance;
     }
 

--- a/src/main/java/com/vmware/burp/extension/domain/HttpMessage.java
+++ b/src/main/java/com/vmware/burp/extension/domain/HttpMessage.java
@@ -6,7 +6,7 @@
 
 package com.vmware.burp.extension.domain;
 
-import burp.BurpExtender;
+import burp.LegacyBurpExtender;
 import burp.ICookie;
 import burp.IExtensionHelpers;
 import burp.IHttpRequestResponse;
@@ -88,7 +88,7 @@ public class HttpMessage {
       this.comment = iHttpRequestResponse.getComment();
       this.highlight = iHttpRequestResponse.getHighlight();
       
-      IExtensionHelpers helpers = BurpExtender.getInstance().getHelpers();
+      IExtensionHelpers helpers = LegacyBurpExtender.getInstance().getHelpers();
       IRequestInfo requestInfo = helpers.analyzeRequest(iHttpRequestResponse);
       this.url = requestInfo.getUrl();
       this.method = requestInfo.getMethod();

--- a/src/main/java/com/vmware/burp/extension/domain/internal/SpiderQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/SpiderQueueMap.java
@@ -6,7 +6,7 @@
 
 package com.vmware.burp.extension.domain.internal;
 
-import burp.BurpExtender;
+import burp.LegacyBurpExtender;
 import burp.IHttpRequestResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +86,7 @@ public class SpiderQueueMap {
         int totalPercentCompletion = 0;
         for (String url : map.keySet()) {
             IHttpRequestResponse[] httpMessageListOld = map.get(url);
-            IHttpRequestResponse[] httpMessageListNew = BurpExtender.getInstance().getCallbacks().getSiteMap(url);
+            IHttpRequestResponse[] httpMessageListNew = LegacyBurpExtender.getInstance().getCallbacks().getSiteMap(url);
 
             if(compareSiteMap(httpMessageListNew, httpMessageListOld)){
                 totalPercentCompletion += 100;
@@ -95,7 +95,7 @@ public class SpiderQueueMap {
             }
         }
 
-        map.replaceAll((url, v) -> BurpExtender.getInstance().getCallbacks().getSiteMap(url));
+        map.replaceAll((url, v) -> LegacyBurpExtender.getInstance().getCallbacks().getSiteMap(url));
 
         if(totalPercentCompletion > 0) {
             int percentComplete = totalPercentCompletion / map.size();

--- a/src/main/java/com/vmware/burp/extension/utils/UserConfigUtils.java
+++ b/src/main/java/com/vmware/burp/extension/utils/UserConfigUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2018 Doyensec LLC.
+ */
+package com.vmware.burp.extension.utils;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class helps in injecting custom extensions to user config through the burp-rest-api command line.
+ */
+public class UserConfigUtils {
+    /**
+     * Extension POJO representing the Burp configuration for a given extension.
+     */
+    public static class Extension {
+        private static Map<String, String> pluginExtToType = new HashMap<String, String>() {{
+            put("jar", "java");
+            put("rb", "ruby");
+            put("py", "python");
+        }};
+        private String errors = "console";
+        private String output = "console";
+        private boolean loaded = true;
+        private String extension_file;
+        private String extension_type;
+        private String name;
+
+        public Extension() {}
+
+        /**
+         * Build a new Extension POJO from a path.
+         * @param path representing the location of a given Burp extension
+         */
+        public Extension(String path) {
+            extension_type = pluginExtToType.get(getFileExtension(path));
+            name = path;
+            extension_file = path;
+        }
+
+        private static String getFileExtension(String name) {
+            int lastIndexOf = name.lastIndexOf(".");
+            if (lastIndexOf == -1) {
+                return ""; // empty extension
+            }
+            return name.substring(lastIndexOf + 1);
+        }
+    }
+
+    private List<Extension> extensions = new ArrayList<>();
+
+    /**
+     * Register a new Burp extension
+     * @param path representing the location of a given Burp extension
+     */
+    public void registerBurpExtension(String path) {
+        extensions.add(new Extension(path));
+    }
+
+
+    /**
+     * Given a userconfig, copy it in a new temporary file and injects all the registered extensions
+     * @param path a userconfig path to be injected
+     * @return a new userconfig path
+     * @throws IOException when one of the two userconfig is not accessible/writable/creatable
+     */
+    public String injectExtensions(String path) throws IOException {
+        Path userOptionsTempFile = Files.createTempFile("user-options_", ".json");
+        FileCopyUtils.copy(new File(path), userOptionsTempFile.toFile());
+
+        //addBurpExtensions here to the temporary file and return the handle to the new temporary file
+        //- read all file in in jackson object
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        JsonNode tree = objectMapper.readTree(userOptionsTempFile.toFile());
+        //- inject the burp extensions here inside the user configuration
+        JsonNode user_options = safeGet(objectMapper, tree, "user_options");
+        JsonNode extender = safeGet(objectMapper, user_options, "extender");
+        JsonNode extension = extender.get("extensions");
+        if (!extension.isArray()) {
+            ArrayNode array = objectMapper.createArrayNode();
+            ((ObjectNode)extender).replace("extensions", array);
+            extension = array;
+        }
+        for (Extension e : extensions) {
+            ((ArrayNode) extension).addPOJO(e);
+        }
+        //- write the jackson configuration inside the temporary user configuration
+        objectMapper.writer(new DefaultPrettyPrinter()).writeValue(userOptionsTempFile.toFile(), tree);
+
+        userOptionsTempFile.toFile().deleteOnExit();
+        return userOptionsTempFile.toAbsolutePath().toString();
+    }
+
+    private static JsonNode safeGet(ObjectMapper objectMapper, JsonNode root, String path) {
+        JsonNode newNode = root.get(path);
+        if (newNode.isMissingNode()) {
+            ObjectNode addNode = objectMapper.createObjectNode();
+            ((ObjectNode)root).replace(path, addNode);
+        }
+        return root.get(path);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,4 +9,4 @@ server:
 headless:
   mode: ${java.awt.headless}
 
-build.version: 1.0.4
+build.version: 2.0.0


### PR DESCRIPTION
This changeset bumps the major version and implements the following 3 features:

1. burp-rest-api now loads the burp jar dinamically throgh the --burp.jar= flag.
2. burp-rest-api is loaded as a 2nd gen extension and is now possible to load
   more than one extension at a time.
3. burp-rest-api can now loads burp 2nd gen extension through the --burp.ext=
   flag.

In order to implement (2) we employed a classloading technique with a dummy
entrypoint _BurpExtender.java_ that loads the legacy burp
extension _LegacyBurpExtension.java_ after the full Burp Suite has been loaded
and launched _BurpService.java_.

**This work has been sponsored by Doyensec LLC** [![Doyensec](https://www.doyensec.com/images/logo.svg)](https://doyensec.com/)