### PR TITLE
Fix burp classloading on Linux

### DIFF
--- a/src/entrypoint/java/burp/BurpExtender.java
+++ b/src/entrypoint/java/burp/BurpExtender.java
@@ -7,6 +7,9 @@ package burp;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * burp.BurpExtender is the burp-rest-api 2nd-gen entrypoint.
@@ -30,17 +33,54 @@ public class BurpExtender implements IBurpExtender {
             legacyRegisterExtenderCallbacks(callbacks);
         } catch (Exception e) {
             PrintWriter stderr = new PrintWriter(callbacks.getStderr(), true);
-            stderr.format("Exception: %s %s %s", e.getClass().getCanonicalName(), e.getCause(),  e.getMessage());
+            stderr.format("Exception: %s %s %s\n%s", e.getClass().getCanonicalName(), e.getCause(),  e.getMessage(), e.getStackTrace());
         }
     }
 
     private static void legacyRegisterExtenderCallbacks(IBurpExtenderCallbacks callbacks)
-            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
-
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        Class clazz = classLoader.loadClass("burp.LegacyBurpExtender");
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException, ClassNotFoundException {
+        Class clazz = loadClass("burp.LegacyBurpExtender");
         Object obj = clazz.newInstance();
         Method method = clazz.getMethod("registerExtenderCallbacks", IBurpExtenderCallbacks.class);
         method.invoke(obj, callbacks);
+    }
+
+    private static Class loadClass(String name) throws ClassNotFoundException{
+        Class clazz = null;
+        Iterator<ClassLoader> cls = getClassloaders().iterator();
+        ClassLoader i = null;
+        if (cls.hasNext())
+            i = cls.next();
+        List<String> css = new ArrayList<>();
+
+        while (clazz == null && i != null) {
+            css.add(i.getClass().getCanonicalName());
+            try {
+                clazz = i.loadClass(name);
+                clazz.newInstance();
+            } catch (ClassNotFoundException|InstantiationException|IllegalAccessException|NoClassDefFoundError e) {
+                clazz = null;
+            }
+            i = i.getParent();
+            if (i == null && cls.hasNext())
+                i = cls.next();
+        }
+
+        if (clazz == null) {
+            throw new ClassNotFoundException("loadClass cannot find the class in any classloader (" + String.join(", ", css) + ").");
+        }
+
+        return clazz;
+    }
+
+    private static Iterable<ClassLoader> getClassloaders() {
+        List<ClassLoader> cls = new ArrayList<>();
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            ClassLoader cl = t.getContextClassLoader();
+            if (cl != null) {
+                cls.add(cl);
+            }
+        }
+        return cls;
     }
 }


### PR DESCRIPTION
On Linux the extensions are not loaded within a Thread that has the contextClassLoader not-null.
In order to find the correct contextClassLoader scan all the Threads in the JVM.

**This work has been sponsored by Doyensec LLC** [![Doyensec](https://www.doyensec.com/images/logo.svg)](https://doyensec.com/)