### PR TITLE
Java Version Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ When the JAR is launched, it provides a REST/JSON endpoint to access the Scanner
 
 #### Prerequisites
 
-* Java 8
+* Java 8 x64
 * Gradle
 * Licensed Burp Suite Professional version 1.7.x or later from: <http://portswigger.net/burp/>
 


### PR DESCRIPTION
The Java Version required by the project is actually Java x64 [here](https://support.portswigger.net/customer/portal/articles/1855756-burp-suite-software)and if we want to build this we're actually going to be needing JDK . I feel like the mention has to be made as I've seen/heard people trying to build this using JRE because burp suite works with just JREx64 but then they install JDK and problems happen .