### PR TITLE
Exposed Scan Status

### DIFF
--- a/src/main/java/com/vmware/burp/extension/client/BurpClient.java
+++ b/src/main/java/com/vmware/burp/extension/client/BurpClient.java
@@ -123,6 +123,11 @@ public class BurpClient {
       return restTemplate.getForObject(uriString, ScanProgress.class).getTotalScanPercentage();
    }
 
+   public String getScanStatus() {
+      String uriString = buildUriFromPathSegments("burp", "scanner", "status");
+      return restTemplate.getForObject(uriString, ScanProgress.class).getScanStatus();
+   }
+
    public ScanIssueList getScanIssues(String urlPrefix) {
       String uriString = buildUriFromPathSegments("burp", "scanner", "issues");
       URI uri = UriComponentsBuilder.fromUriString(uriString).queryParam("urlPrefix", urlPrefix)

--- a/src/main/java/com/vmware/burp/extension/domain/ScanProgress.java
+++ b/src/main/java/com/vmware/burp/extension/domain/ScanProgress.java
@@ -19,6 +19,7 @@ public class ScanProgress {
    @JsonProperty("scanPercentage")
    @XmlElement(name = "scanPercentage", required = true)
    private int totalScanPercentage;
+   private String scanStatus;
 
    public int getTotalScanPercentage() {
       return totalScanPercentage;
@@ -26,5 +27,13 @@ public class ScanProgress {
 
    public void setTotalScanPercentage(int totalScanPercentage) {
       this.totalScanPercentage = totalScanPercentage;
+   }
+
+   public String getScanStatus(){
+      return scanStatus;
+   }
+
+   public void setScanStatus(String scanStatus){
+      this.scanStatus = scanStatus;
    }
 }

--- a/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
@@ -86,4 +86,16 @@ public class ScanQueueMap {
          return 0;
       }
    }
+
+   public String getScanStatus(){
+      String status = "none";
+      for (String url : map.keySet()) {
+         for (IScanQueueItem iScanQueueItem : getQueue(url)) {
+            status = iScanQueueItem.getStatus();
+            log.info("Scan Percent Complete: {}", status);
+            return status;
+         }
+      }
+      return status;
+   }
 }

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -368,6 +368,11 @@ public class BurpService {
         return scans.getPercentageComplete();
     }
 
+    public String getScanStatus() {
+        log.info("Getting Scanner Status.");
+        return scans.getScanStatus();
+    }
+
     public int getSpiderPercentageComplete() {
         log.info("Estimate Spider percentage complete.");
         return spiders.getPercentageComplete();

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -304,6 +304,7 @@ public class BurpController {
    public ScanProgress scanPercentComplete() {
       ScanProgress scanProgress = new ScanProgress();
       scanProgress.setTotalScanPercentage(burp.getScanPercentageComplete());
+      scanProgress.setScanStatus(burp.getScanStatus());
       return scanProgress;
    }
 


### PR DESCRIPTION
Addressing issue for Scan Status, this will add one more field to the response /burp/scanner/status, with scanStatus: "none" being default at start. scanPercentage is left untouched.