### PR TITLE
Add support for filtering report issues by severity/confidence/paths

### DIFF
--- a/src/main/java/com/vmware/burp/extension/domain/IssueConfidence.java
+++ b/src/main/java/com/vmware/burp/extension/domain/IssueConfidence.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.vmware.burp.extension.domain;
+
+public enum IssueConfidence {
+    All("All"), Certain("Certain"), Firm("Firm"), Tentative("Tentative");
+
+    private final String issueConfidence;
+
+    IssueConfidence(String issueConfidence) {
+        this.issueConfidence = issueConfidence;
+    }
+
+    public String getIssueConfidence() {
+        return issueConfidence;
+    }
+}

--- a/src/main/java/com/vmware/burp/extension/domain/IssueSeverity.java
+++ b/src/main/java/com/vmware/burp/extension/domain/IssueSeverity.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.vmware.burp.extension.domain;
+
+public enum IssueSeverity {
+    All("All"), High("High"), Medium("Medium"), Low("Low"), Information("Information");
+
+    private final String issueSeverity;
+
+    IssueSeverity(String issueSeverity) {
+        this.issueSeverity = issueSeverity;
+    }
+
+    public String getIssueSeverity() {
+        return issueSeverity;
+    }
+}

--- a/src/main/java/com/vmware/burp/extension/utils/Utils.java
+++ b/src/main/java/com/vmware/burp/extension/utils/Utils.java
@@ -9,6 +9,8 @@ package com.vmware.burp.extension.utils;
 import com.vmware.burp.extension.domain.Config;
 import com.vmware.burp.extension.domain.ConfigItem;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,5 +22,13 @@ public class Utils {
          configMap.put(configItem.getProperty(), configItem.getValue());
       }
       return configMap;
+   }
+
+   public static String convertURLToStringWithoutPort(URL url) {
+      try {
+         return new URL(url.getProtocol(), url.getHost(), url.getFile()).toString();
+      } catch (MalformedURLException e) {
+         return null;
+      }
    }
 }

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.NoRouteToHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -273,7 +274,10 @@ public class BurpController {
    @ApiOperation(value = "Get the scan report with Scanner issues", notes = "Returns the scan report with current Scanner issues for URLs matching the specified urlPrefix in the form of a byte array. Report format can be specified as HTML or XML. Report with scan issues of all URLs are returned in HTML format if no urlPrefix and format are specified.")
    @ApiImplicitParams({
          @ApiImplicitParam(name = "urlPrefix", value = "URL prefix in order to extract and include a specific subset of scan issues in the report.", dataType = "string", paramType = "query"),
-         @ApiImplicitParam(name = "reportType", value = "Format to be used to generate report. Acceptable values are HTML and XML.", defaultValue = "HTML", dataType = "string", paramType = "query")
+         @ApiImplicitParam(name = "reportType", value = "Format to be used to generate report. Acceptable values are HTML and XML.", defaultValue = "HTML", dataType = "string", paramType = "query"),
+         @ApiImplicitParam(name = "issueSeverity", value = "Severity of the scan issues to be included in the report. Acceptable values are All, High, Medium, Low and Information. Multiple values are also accepted if they are comma-separated.", defaultValue = "All", dataType = "string", paramType = "query"),
+         @ApiImplicitParam(name = "issueConfidence", value = "Confidence of the scan issues to be included in the report. Acceptable values are All, Certain, Firm and Tentative. Multiple values are also accepted if they are comma-separated.", defaultValue = "All", dataType = "string", paramType = "query"),
+         @ApiImplicitParam(name = "issuePath", value = "Path of the scan issues to be included in the report. Multiple values are accepted if they are comma-separated.", dataType = "string", paramType = "query")
    })
    @ApiResponses(value = {
          @ApiResponse(code = 200, message = "Success", response = Byte[].class),
@@ -282,7 +286,10 @@ public class BurpController {
    })
    @RequestMapping(method = GET, value = "/report")
    public byte[] generateReport(@RequestParam(required = false) String urlPrefix,
-         @RequestParam(required = false, defaultValue = "HTML") String reportType)
+                                @RequestParam(required = false, defaultValue = "HTML") String reportType,
+                                @RequestParam(required = false, defaultValue = "All") String issueSeverity,
+                                @RequestParam(required = false, defaultValue = "All") String issueConfidence,
+                                @RequestParam(required = false) String issuePath)
          throws IOException {
       try {
          ReportType.valueOf(reportType);
@@ -292,7 +299,37 @@ public class BurpController {
                "Invalid value for the reportType parameter. Valid values: HTML, XML.");
       }
 
-      return burp.generateScanReport(urlPrefix, ReportType.valueOf(reportType));
+      List<IssueSeverity> issueSeverities = new ArrayList<>();
+      try {
+         for (String sev : issueSeverity.split(",")) {
+            issueSeverities.add(IssueSeverity.valueOf(sev.trim()));
+         }
+      } catch (Exception e) {
+         log.error("Invalid Issue Severity in the request: {}", issueSeverity);
+         throw new IllegalArgumentException(
+                 "Invalid value for the issueSeverity parameter. Valid values: All, High, Medium, Low, Information.");
+      }
+
+      List<IssueConfidence> issueConfidences = new ArrayList<>();
+      try {
+         for (String conf : issueConfidence.split(",")) {
+            issueConfidences.add(IssueConfidence.valueOf(conf.trim()));
+         }
+      } catch (Exception e) {
+         log.error("Invalid Issue Confidence in the request: {}", issueConfidence);
+         throw new IllegalArgumentException(
+                 "Invalid value for the issueConfidence parameter. Valid values: All, Certain, Firm, Tentative.");
+      }
+
+      List<String> issuePaths = new ArrayList<>();
+      if (issuePath != null && !issuePath.trim().isEmpty()) {
+         issuePaths = Arrays.stream(issuePath.split(","))
+                 .map(String :: trim)
+                 .collect(Collectors.toList());
+      }
+
+      return burp.generateScanReport(urlPrefix, ReportType.valueOf(reportType), issueSeverities.toArray(new IssueSeverity[0]),
+              issueConfidences.toArray(new IssueConfidence[0]), issuePaths.toArray(new String[0]));
    }
 
    @ApiOperation(value = "Get the percentage completed for the scan queue items", notes = "Returns an aggregate of percentage completed for all the scan queue items.")

--- a/src/test/java/com/vmware/burp/extension/client/BurpClientIT.java
+++ b/src/test/java/com/vmware/burp/extension/client/BurpClientIT.java
@@ -9,6 +9,8 @@ package com.vmware.burp.extension.client;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.vmware.burp.extension.domain.HttpMessageList;
+import com.vmware.burp.extension.domain.IssueConfidence;
+import com.vmware.burp.extension.domain.IssueSeverity;
 import com.vmware.burp.extension.domain.ReportType;
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
@@ -124,19 +126,29 @@ public class BurpClientIT {
         assertEquals(100, burpClient.getScannerStatus());
 
         String urlPrefix = "https://www.vmware.com";
+        IssueSeverity[] issueSeverity = new IssueSeverity[] { IssueSeverity.High, IssueSeverity.Medium };
+        IssueConfidence[] issueConfidence = new IssueConfidence[] { IssueConfidence.Certain };
 
         sendRequestThruProxy();
 
-        assertNotNull(burpClient.getReportData(ReportType.HTML));
-        assertNotNull(burpClient.getReportData(ReportType.XML));
+        assertNotNull(burpClient.getReportData(urlPrefix, null, null, null));
+        assertNotNull(burpClient.getReportData(urlPrefix, ReportType.HTML, null, null));
+        assertNotNull(burpClient.getReportData(urlPrefix, ReportType.XML, null, null));
+        assertNotNull(burpClient.getReportData(urlPrefix, ReportType.HTML, issueSeverity, null));
+        assertNotNull(burpClient.getReportData(urlPrefix, ReportType.HTML, null, issueConfidence));
+        assertNotNull(burpClient.getReportData(urlPrefix, ReportType.HTML, issueSeverity, issueConfidence));
 
         burpClient.includeInScope(urlPrefix);
         burpClient.spider(urlPrefix);
         burpClient.scan(urlPrefix);
+
         assertNotEquals(100, burpClient.getScannerStatus());
+
         Thread.sleep(4000);
+
         assertNotEquals(0, burpClient.getScanIssues().getScanIssues().size());
         assertNotEquals(0, burpClient.getScanIssues(urlPrefix).getScanIssues().size());
+
         burpClient.excludeFromScope(urlPrefix);
     }
 


### PR DESCRIPTION
@ikkisoft This adds the Severity, Confidence and Path filters in the `/burp/report` endpoint, as suggested in #125 