### PR TITLE
Improved launcher script for Mac/Linux

### DIFF
--- a/burp-rest-api.sh
+++ b/burp-rest-api.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -xe
-SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-CLASSPATH="$(echo $SCRIPTPATH/build/libs/*.jar | tr ' ' ':'):$(echo $SCRIPTPATH/*.jar | tr ' ' ':')"
+SCRIPTPATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
+CLASSPATH="$(find $SCRIPTPATH -name "*burp*.jar" -exec sh -c "echo {}: | tr -d '\n'" \;)"
 java -cp "$CLASSPATH" org.springframework.boot.loader.JarLauncher $@


### PR DESCRIPTION
Changed _burp-rest-api.sh_ to look for all required JARs despite their location within the app folder.