### PR TITLE
Fix scan status issue

### DIFF
--- a/src/main/java/com/vmware/burp/extension/client/BurpClient.java
+++ b/src/main/java/com/vmware/burp/extension/client/BurpClient.java
@@ -8,11 +8,11 @@ package com.vmware.burp.extension.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.vmware.burp.extension.domain.ScanStatusList;
 import com.vmware.burp.extension.domain.Config;
 import com.vmware.burp.extension.domain.HttpMessageList;
 import com.vmware.burp.extension.domain.ReportType;
 import com.vmware.burp.extension.domain.ScanIssueList;
-import com.vmware.burp.extension.domain.ScanProgress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
@@ -28,7 +28,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -118,14 +117,9 @@ public class BurpClient {
 
    //TODO: Client method for clearScans. Is this needed?
 
-   public int getScannerStatus() {
+   public ScanStatusList getScanStatuses() {
       String uriString = buildUriFromPathSegments("burp", "scanner", "status");
-      return restTemplate.getForObject(uriString, ScanProgress.class).getTotalScanPercentage();
-   }
-
-   public String getScanStatus() {
-      String uriString = buildUriFromPathSegments("burp", "scanner", "status");
-      return restTemplate.getForObject(uriString, ScanProgress.class).getScanStatus();
+      return restTemplate.getForObject(uriString, ScanStatusList.class);
    }
 
    public ScanIssueList getScanIssues(String urlPrefix) {

--- a/src/main/java/com/vmware/burp/extension/client/BurpClient.java
+++ b/src/main/java/com/vmware/burp/extension/client/BurpClient.java
@@ -123,6 +123,11 @@ public class BurpClient {
       return restTemplate.getForObject(uriString, ScanProgress.class).getTotalScanPercentage();
    }
 
+   public String getScanStatus() {
+      String uriString = buildUriFromPathSegments("burp", "scanner", "status");
+      return restTemplate.getForObject(uriString, ScanProgress.class).getScanStatus();
+   }
+
    public ScanIssueList getScanIssues(String urlPrefix) {
       String uriString = buildUriFromPathSegments("burp", "scanner", "issues");
       URI uri = UriComponentsBuilder.fromUriString(uriString).queryParam("urlPrefix", urlPrefix)

--- a/src/main/java/com/vmware/burp/extension/domain/ScanProgress.java
+++ b/src/main/java/com/vmware/burp/extension/domain/ScanProgress.java
@@ -19,6 +19,7 @@ public class ScanProgress {
    @JsonProperty("scanPercentage")
    @XmlElement(name = "scanPercentage", required = true)
    private int totalScanPercentage;
+   private String scanStatus;
 
    public int getTotalScanPercentage() {
       return totalScanPercentage;
@@ -26,5 +27,13 @@ public class ScanProgress {
 
    public void setTotalScanPercentage(int totalScanPercentage) {
       this.totalScanPercentage = totalScanPercentage;
+   }
+
+   public String getScanStatus(){
+      return scanStatus;
+   }
+
+   public void setScanStatus(String scanStatus){
+      this.scanStatus = scanStatus;
    }
 }

--- a/src/main/java/com/vmware/burp/extension/domain/ScanStatus.java
+++ b/src/main/java/com/vmware/burp/extension/domain/ScanStatus.java
@@ -21,6 +21,8 @@ public class ScanStatus {
     @XmlElement(required = true)
     private String status;
 
+    private ScanStatus() { }
+
     public ScanStatus(String url, String status) {
         this.url = url;
         this.status = status;

--- a/src/main/java/com/vmware/burp/extension/domain/ScanStatus.java
+++ b/src/main/java/com/vmware/burp/extension/domain/ScanStatus.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.vmware.burp.extension.domain;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ScanStatus {
+
+    @XmlElement(required = true)
+    private String url;
+
+    @XmlElement(required = true)
+    private String status;
+
+    public ScanStatus(String url, String status) {
+        this.url = url;
+        this.status = status;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/vmware/burp/extension/domain/ScanStatusList.java
+++ b/src/main/java/com/vmware/burp/extension/domain/ScanStatusList.java
@@ -7,33 +7,26 @@
 package com.vmware.burp.extension.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vmware.burp.extension.domain.ScanStatus;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
 
-@XmlRootElement(name = "scanProgress")
+@XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-public class ScanProgress {
-   @JsonProperty("scanPercentage")
-   @XmlElement(name = "scanPercentage", required = true)
-   private int totalScanPercentage;
-   private String scanStatus;
+public class ScanStatusList {
+    @JsonProperty("scans")
+    @XmlElement(required = true)
+    private List<ScanStatus> scanStatuses;
 
-   public int getTotalScanPercentage() {
-      return totalScanPercentage;
-   }
+    public List<ScanStatus> getScanStatuses() {
+        return scanStatuses;
+    }
 
-   public void setTotalScanPercentage(int totalScanPercentage) {
-      this.totalScanPercentage = totalScanPercentage;
-   }
-
-   public String getScanStatus(){
-      return scanStatus;
-   }
-
-   public void setScanStatus(String scanStatus){
-      this.scanStatus = scanStatus;
-   }
+    public void setScanStatuses(List<ScanStatus> scanStatuses) {
+        this.scanStatuses = scanStatuses;
+    }
 }

--- a/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
@@ -87,15 +87,13 @@ public class ScanQueueMap {
       }
    }
 
-   public String getScanStatus(){
-      String status = "none";
+   public List<String[]> getScanStatuses() {
+      List<String[]> statuses = new ArrayList<>();
       for (String url : map.keySet()) {
          for (IScanQueueItem iScanQueueItem : getQueue(url)) {
-            status = iScanQueueItem.getStatus();
-            log.info("Scan Percent Complete: {}", status);
-            return status;
+            statuses.add(new String[]{url, iScanQueueItem.getStatus()});
          }
       }
-      return status;
+      return statuses;
    }
 }

--- a/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
+++ b/src/main/java/com/vmware/burp/extension/domain/internal/ScanQueueMap.java
@@ -86,4 +86,16 @@ public class ScanQueueMap {
          return 0;
       }
    }
+
+   public String getScanStatus(){
+      String status = "none";
+      for (String url : map.keySet()) {
+         for (IScanQueueItem iScanQueueItem : getQueue(url)) {
+            status = iScanQueueItem.getStatus();
+            log.info("Scan Percent Complete: {}", status);
+            return status;
+         }
+      }
+      return status;
+   }
 }

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -10,6 +10,7 @@ import burp.*;
 import com.vmware.burp.extension.domain.HttpMessage;
 import com.vmware.burp.extension.domain.ReportType;
 import com.vmware.burp.extension.domain.ScanIssue;
+import com.vmware.burp.extension.domain.ScanStatus;
 import com.vmware.burp.extension.domain.internal.ScanQueueMap;
 import com.vmware.burp.extension.domain.internal.SpiderQueueMap;
 import com.vmware.burp.extension.utils.UserConfigUtils;
@@ -35,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -363,14 +365,11 @@ public class BurpService {
         return Files.readAllBytes(reportFile);
     }
 
-    public int getScanPercentageComplete() {
-        log.info("Getting Scanner percentage complete.");
-        return scans.getPercentageComplete();
-    }
-
-    public String getScanStatus() {
-        log.info("Getting Scanner Status.");
-        return scans.getScanStatus();
+    public List<ScanStatus> getScanStatuses() {
+        log.info("Retrieving Scans statuses.");
+        return scans.getScanStatuses().stream()
+                .map(status -> new ScanStatus(status[0], status[1]))
+                .collect(Collectors.toList());
     }
 
     public int getSpiderPercentageComplete() {

--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -368,6 +368,11 @@ public class BurpService {
         return scans.getPercentageComplete();
     }
 
+    public String getScanStatus() {
+        log.info("Getting Scanner Status.");
+        return scans.getScanStatus();
+    }
+
     public int getSpiderPercentageComplete() {
         log.info("Estimate Spider percentage complete.");
         return spiders.getPercentageComplete();

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -304,6 +304,7 @@ public class BurpController {
    public ScanProgress scanPercentComplete() {
       ScanProgress scanProgress = new ScanProgress();
       scanProgress.setTotalScanPercentage(burp.getScanPercentageComplete());
+      scanProgress.setScanStatus(burp.getScanStatus());
       return scanProgress;
    }
 

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -8,6 +8,7 @@ package com.vmware.burp.extension.web;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vmware.burp.extension.domain.ScanStatusList;
 import com.vmware.burp.extension.domain.*;
 import com.vmware.burp.extension.service.BurpService;
 import io.swagger.annotations.ApiImplicitParam;
@@ -295,17 +296,16 @@ public class BurpController {
       return burp.generateScanReport(urlPrefix, ReportType.valueOf(reportType));
    }
 
-   @ApiOperation(value = "Get the percentage completed for the scan queue items", notes = "Returns an aggregate of percentage completed for all the scan queue items.")
+   @ApiOperation(value = "Get the status of each scan", notes = "Returns status details of items in the scan queue.")
    @ApiResponses(value = {
-         @ApiResponse(code = 200, message = "Success", response = ScanProgress.class),
+         @ApiResponse(code = 200, message = "Success", response = ScanStatusList.class),
          @ApiResponse(code = 500, message = "Failure")
    })
    @RequestMapping(method = GET, value = "/scanner/status")
-   public ScanProgress scanPercentComplete() {
-      ScanProgress scanProgress = new ScanProgress();
-      scanProgress.setTotalScanPercentage(burp.getScanPercentageComplete());
-      scanProgress.setScanStatus(burp.getScanStatus());
-      return scanProgress;
+   public ScanStatusList scanPercentComplete() {
+      ScanStatusList scanStatusList = new ScanStatusList();
+      scanStatusList.setScanStatuses(burp.getScanStatuses());
+      return scanStatusList;
    }
 
     @ApiOperation(value = "Get the status of the spider", notes = "Returns an estimate of the current status of the spider. Due to the current limitations in Burp's Extender API, this endpoint will return 100% whenever the spider is no longer discovering new resources. On newer Burp APIs, we expect to be able to provide discrete values.")

--- a/src/test/java/com/vmware/burp/extension/client/BurpClientIT.java
+++ b/src/test/java/com/vmware/burp/extension/client/BurpClientIT.java
@@ -121,7 +121,7 @@ public class BurpClientIT {
 
     @Test
     public void testScannerSpiderAndReportMethods() throws IOException, InterruptedException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
-        assertEquals(100, burpClient.getScannerStatus());
+        assertEquals(0, burpClient.getScanStatuses().getScanStatuses().size());
 
         String urlPrefix = "https://www.vmware.com";
 
@@ -133,7 +133,7 @@ public class BurpClientIT {
         burpClient.includeInScope(urlPrefix);
         burpClient.spider(urlPrefix);
         burpClient.scan(urlPrefix);
-        assertNotEquals(100, burpClient.getScannerStatus());
+        assertNotEquals(0, burpClient.getScanStatuses().getScanStatuses().size());
         Thread.sleep(4000);
         assertNotEquals(0, burpClient.getScanIssues().getScanIssues().size());
         assertNotEquals(0, burpClient.getScanIssues(urlPrefix).getScanIssues().size());


### PR DESCRIPTION
@ikkisoft This addresses the issue in #118 by retrieving a list of the scans and their corresponding statuses in the endpoint `/scanner/status`.
The scan percentage field has been removed from the response since the method `IScanQueueItem.getPercentageComplete()` is deprecated.