### PR TITLE
Fixing Issue #157 and probably others

### DIFF
--- a/src/main/java/com/vmware/burp/extension/service/BurpService.java
+++ b/src/main/java/com/vmware/burp/extension/service/BurpService.java
@@ -268,12 +268,12 @@ public class BurpService {
                 input.stream().allMatch(i -> i.length == 2 && i[0] < i[1]);
     }
 
-    public boolean scan(String baseUrl, boolean isActive) throws MalformedURLException, NoRouteToHostException {
+    public boolean scan(String baseUrl, boolean isActive) throws MalformedURLException, NoRouteToHostException, URISyntaxException {
         return this.scan(baseUrl, isActive, null);
     }
 
     public boolean scan(String baseUrl, boolean isActive, List<int[]> insertionPoints)
-            throws MalformedURLException, NoRouteToHostException {
+            throws MalformedURLException, NoRouteToHostException, URISyntaxException {
         boolean inScope = isInScope(baseUrl);
         log.info("Total SiteMap size: {}", LegacyBurpExtender.getInstance().getCallbacks().getSiteMap("").length);
         log.info("Is {} in Scope: {}", baseUrl, inScope);
@@ -295,7 +295,7 @@ public class BurpService {
                 throw new NoRouteToHostException("Active Scan Target Did Not Respond");
             }
             LegacyBurpExtender.getInstance().getCallbacks().addToSiteMap(reqResHttpService);
-            IHttpRequestResponse[] siteMapInScope = LegacyBurpExtender.getInstance().getCallbacks().getSiteMap(baseUrl);
+            IHttpRequestResponse[] siteMapInScope = Utils.getSiteMapWrapper(baseUrl);
             log.info("Number of URLs submitting for Active/Passive Scan: {}", siteMapInScope.length);
             for (IHttpRequestResponse iHttpRequestResponse : siteMapInScope) {
                 URL url = LegacyBurpExtender.getInstance().getHelpers().analyzeRequest(iHttpRequestResponse)
@@ -350,10 +350,9 @@ public class BurpService {
         scans.clear();
     }
 
-    public List<HttpMessage> getSiteMap(String urlPrefix) throws UnsupportedEncodingException {
+    public List<HttpMessage> getSiteMap(String urlPrefix) throws UnsupportedEncodingException, MalformedURLException {
         List<HttpMessage> httpMessageList = new ArrayList<>();
-        for (IHttpRequestResponse iHttpRequestResponse : LegacyBurpExtender.getInstance().getCallbacks()
-                .getSiteMap(urlPrefix)) {
+        for (IHttpRequestResponse iHttpRequestResponse : Utils.getSiteMapWrapper(urlPrefix)) {
             httpMessageList.add(new HttpMessage(iHttpRequestResponse));
         }
         return httpMessageList;
@@ -442,7 +441,7 @@ public class BurpService {
         return scans.getPercentageComplete();
     }
 
-    public int getSpiderPercentageComplete() {
+    public int getSpiderPercentageComplete() throws MalformedURLException {
         log.info("Estimate Spider percentage complete.");
         return spiders.getPercentageComplete();
     }
@@ -450,7 +449,7 @@ public class BurpService {
     public void sendToSpider(String baseUrl) throws MalformedURLException {
         URL url = new URL(baseUrl);
         LegacyBurpExtender.getInstance().getCallbacks().sendToSpider(url);
-        spiders.addItem(url.toString(),LegacyBurpExtender.getInstance().getCallbacks().getSiteMap(url.toString()));
+        spiders.addItem(url.toString(),Utils.getSiteMapWrapper(baseUrl));
     }
 
     public List<ICookie> getCookieFromCookieJar() {

--- a/src/main/java/com/vmware/burp/extension/utils/Utils.java
+++ b/src/main/java/com/vmware/burp/extension/utils/Utils.java
@@ -6,6 +6,8 @@
 
 package com.vmware.burp.extension.utils;
 
+import burp.IHttpRequestResponse;
+import burp.LegacyBurpExtender;
 import com.vmware.burp.extension.domain.Config;
 import com.vmware.burp.extension.domain.ConfigItem;
 
@@ -22,6 +24,17 @@ public class Utils {
          configMap.put(configItem.getProperty(), configItem.getValue());
       }
       return configMap;
+   }
+
+   public static IHttpRequestResponse[] getSiteMapWrapper(String urlPrefix) throws MalformedURLException {
+      URL target = new URL(urlPrefix);
+      boolean isHttps = target.getProtocol().equalsIgnoreCase("HTTPS");
+      int targetPort = target.getPort() != -1 ? target.getPort() : (isHttps ? 443 : 80);
+      if(targetPort == 80 || targetPort == 443){
+         return LegacyBurpExtender.getInstance().getCallbacks().getSiteMap(Utils.convertURLToStringWithoutPort(target));
+      }else {
+         return LegacyBurpExtender.getInstance().getCallbacks().getSiteMap(urlPrefix);
+      }
    }
 
    public static String convertURLToStringWithoutPort(URL url) {

--- a/src/main/java/com/vmware/burp/extension/web/BurpController.java
+++ b/src/main/java/com/vmware/burp/extension/web/BurpController.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.NoRouteToHostException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -167,7 +168,7 @@ public class BurpController {
          @ApiResponse(code = 500, message = "Failure")
    })
    @RequestMapping(method = GET, value = "/target/sitemap")
-   public HttpMessageList getSiteMap(@RequestParam(required = false) String urlPrefix) throws UnsupportedEncodingException {
+   public HttpMessageList getSiteMap(@RequestParam(required = false) String urlPrefix) throws UnsupportedEncodingException, MalformedURLException {
       HttpMessageList httpMessageList = new HttpMessageList();
       httpMessageList.setHttpMessages(burp.getSiteMap(urlPrefix));
       return httpMessageList;
@@ -240,7 +241,7 @@ public class BurpController {
    })
    @RequestMapping(method = POST, value = "/scanner/scans/passive")
    public void scanPassive(@RequestParam(value = "baseUrl") String baseUrl)
-           throws MalformedURLException, NoRouteToHostException {
+           throws MalformedURLException, NoRouteToHostException, URISyntaxException {
       if (StringUtils.isEmpty(baseUrl)) {
          throw new IllegalArgumentException("The 'baseUrl' parameter in payload must not be null or empty.");
       }
@@ -270,7 +271,7 @@ public class BurpController {
            @RequestParam(value = "baseUrl") String baseUrl,
            @RequestParam(value = "insertionPoint", required = false) List<String> insertionPoints
    )
-           throws MalformedURLException, NoRouteToHostException {
+           throws MalformedURLException, NoRouteToHostException, URISyntaxException {
       if (StringUtils.isEmpty(baseUrl)) {
          throw new IllegalArgumentException("The 'baseUrl' parameter in payload must not be null or empty.");
       }
@@ -408,7 +409,7 @@ public class BurpController {
             @ApiResponse(code = 500, message = "Failure")
     })
     @RequestMapping(method = GET, value = "/spider/status")
-    public SpiderProgress spiderPercentComplete() {
+    public SpiderProgress spiderPercentComplete() throws MalformedURLException {
         SpiderProgress spiderProgress = new SpiderProgress();
         spiderProgress.setTotalSpiderPercentage(burp.getSpiderPercentageComplete());
         return spiderProgress;


### PR DESCRIPTION
Unlike [isInScope](https://portswigger.net/burp/extender/api/burp/IBurpExtenderCallbacks.html#isInScope-java.net.URL-), [getSiteMap](https://portswigger.net/burp/extender/api/burp/IBurpExtenderCallbacks.html#getSiteMap-java.lang.String-) works out of string URLs and does not remove the port if standard 80/443. 

This issue was probably affecting a few endpoints.

Testing:
* Executed the standard tests
* Attempted to reproduce #157 

Additional testing would be good.